### PR TITLE
Enable HTTP/2 protocol for Cloudflare Tunnel

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,7 +77,7 @@ services:
   tunnel:
     image: cloudflare/cloudflared:latest
     restart: unless-stopped
-    command: tunnel --no-autoupdate run
+    command: tunnel --no-autoupdate --protocol http2 run
     environment:
       TUNNEL_TOKEN: ${CLOUDFLARE_TUNNEL_TOKEN}
     depends_on:


### PR DESCRIPTION
## Summary
Updated the Cloudflare Tunnel configuration to explicitly enable HTTP/2 protocol support.

## Changes
- Added `--protocol http2` flag to the cloudflared tunnel command in docker-compose.yml

## Details
This change enables HTTP/2 as the protocol for the Cloudflare Tunnel connection, which can provide improved performance and efficiency compared to HTTP/1.1 through features like multiplexing and header compression.

https://claude.ai/code/session_01TxyoWfZNUcnSYCZwLDK39M