### PR TITLE
fix: specify database name in pg_isready healthcheck

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -10,7 +10,7 @@ services:
       - pgdata:/var/lib/postgresql/data
     # Not exposed externally — only reachable by scraper/web on the backend network
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U mtg"]
+      test: ["CMD-SHELL", "pg_isready -U mtg -d mtg_tracker"]
       interval: 5s
       retries: 5
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     volumes:
       - pgdata:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U mtg"]
+      test: ["CMD-SHELL", "pg_isready -U mtg -d mtg_tracker"]
       interval: 5s
       retries: 5
 


### PR DESCRIPTION
pg_isready -U mtg without -d defaults to connecting to a database named after the user ("mtg"), which doesn't exist. This caused a FATAL error logged every 5s, flooding Loki. Adding -d mtg_tracker targets the correct database.

https://claude.ai/code/session_01UE8tqB5eytZvxiAXLSy17X