### PR TITLE
Add MTG set price tracking pages with detailed analytics

### DIFF
--- a/apps/scraper/drizzle/0008_powerful_harpoon.sql
+++ b/apps/scraper/drizzle/0008_powerful_harpoon.sql
@@ -1,0 +1,17 @@
+CREATE TABLE "sets" (
+	"set_code" text PRIMARY KEY NOT NULL,
+	"set_name" text NOT NULL,
+	"set_type" text,
+	"parent_set_code" text,
+	"released_at" date NOT NULL,
+	"card_count" integer DEFAULT 0 NOT NULL,
+	"icon_svg_uri" text
+);
+
+-- Backfill from existing printings so the table isn't empty before the first
+-- Scryfall re-import. set_type and parent_set_code will be NULL until then.
+INSERT INTO "sets" (set_code, set_name, released_at)
+SELECT DISTINCT ON (set_code) set_code, set_name, MIN(released_at)
+FROM printings
+GROUP BY set_code, set_name
+ON CONFLICT DO NOTHING;

--- a/apps/scraper/drizzle/0009_set_value_aud.sql
+++ b/apps/scraper/drizzle/0009_set_value_aud.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "sets" ADD COLUMN "set_value_aud" numeric;

--- a/apps/scraper/drizzle/meta/0008_snapshot.json
+++ b/apps/scraper/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,847 @@
+{
+  "id": "08fecc14-9067-479a-9c36-85b67276c955",
+  "prevId": "6c5fe0d5-e775-4285-870d-368d483a308b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.card_searches": {
+      "name": "card_searches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "card_id": {
+          "name": "card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "searched_at": {
+          "name": "searched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "card_searches_card_id_idx": {
+          "name": "card_searches_card_id_idx",
+          "columns": [
+            {
+              "expression": "card_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "card_searches_searched_at_idx": {
+          "name": "card_searches_searched_at_idx",
+          "columns": [
+            {
+              "expression": "searched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "card_searches_card_id_cards_id_fk": {
+          "name": "card_searches_card_id_cards_id_fk",
+          "tableFrom": "card_searches",
+          "tableTo": "cards",
+          "columnsFrom": [
+            "card_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cards": {
+      "name": "cards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mana_cost": {
+          "name": "mana_cost",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type_line": {
+          "name": "type_line",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oracle_text": {
+          "name": "oracle_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "colors": {
+          "name": "colors",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "color_identity": {
+          "name": "color_identity",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "legalities": {
+          "name": "legalities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cards_name_idx": {
+          "name": "cards_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cards_slug_idx": {
+          "name": "cards_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ebay_search_log": {
+      "name": "ebay_search_log",
+      "schema": "",
+      "columns": {
+        "card_name": {
+          "name": "card_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_searched_at": {
+          "name": "last_searched_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_result_count": {
+          "name": "last_result_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.price_history": {
+      "name": "price_history",
+      "schema": "",
+      "columns": {
+        "printing_id": {
+          "name": "printing_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "store_id": {
+          "name": "store_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_aud": {
+          "name": "price_aud",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_type": {
+          "name": "price_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "price_history_unique_daily_idx": {
+          "name": "price_history_unique_daily_idx",
+          "columns": [
+            {
+              "expression": "printing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "store_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "price_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "price_history_recorded_at_idx": {
+          "name": "price_history_recorded_at_idx",
+          "columns": [
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "price_history_store_id_idx": {
+          "name": "price_history_store_id_idx",
+          "columns": [
+            {
+              "expression": "store_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "price_history_printing_id_printings_id_fk": {
+          "name": "price_history_printing_id_printings_id_fk",
+          "tableFrom": "price_history",
+          "tableTo": "printings",
+          "columnsFrom": [
+            "printing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "price_history_store_id_stores_id_fk": {
+          "name": "price_history_store_id_stores_id_fk",
+          "tableFrom": "price_history",
+          "tableTo": "stores",
+          "columnsFrom": [
+            "store_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.printings": {
+      "name": "printings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "card_id": {
+          "name": "card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "set_code": {
+          "name": "set_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "set_name": {
+          "name": "set_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1993-01-01'"
+        },
+        "collector_number": {
+          "name": "collector_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rarity": {
+          "name": "rarity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_foil": {
+          "name": "is_foil",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image_uri": {
+          "name": "image_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_uri_back": {
+          "name": "image_uri_back",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scryfall_uri": {
+          "name": "scryfall_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usd_price": {
+          "name": "usd_price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "printings_card_id_idx": {
+          "name": "printings_card_id_idx",
+          "columns": [
+            {
+              "expression": "card_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "printings_set_code_idx": {
+          "name": "printings_set_code_idx",
+          "columns": [
+            {
+              "expression": "set_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "printings_card_id_cards_id_fk": {
+          "name": "printings_card_id_cards_id_fk",
+          "tableFrom": "printings",
+          "tableTo": "cards",
+          "columnsFrom": [
+            "card_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sets": {
+      "name": "sets",
+      "schema": "",
+      "columns": {
+        "set_code": {
+          "name": "set_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "set_name": {
+          "name": "set_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "set_type": {
+          "name": "set_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_set_code": {
+          "name": "parent_set_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "card_count": {
+          "name": "card_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "icon_svg_uri": {
+          "name": "icon_svg_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.store_prices": {
+      "name": "store_prices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "printing_id": {
+          "name": "printing_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "store_id": {
+          "name": "store_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_aud": {
+          "name": "price_aud",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shipping_aud": {
+          "name": "shipping_aud",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_type": {
+          "name": "price_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "in_stock": {
+          "name": "in_stock",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scraped_at": {
+          "name": "scraped_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "store_prices_printing_store_idx": {
+          "name": "store_prices_printing_store_idx",
+          "columns": [
+            {
+              "expression": "printing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "store_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_prices_store_id_idx": {
+          "name": "store_prices_store_id_idx",
+          "columns": [
+            {
+              "expression": "store_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "store_prices_printing_id_printings_id_fk": {
+          "name": "store_prices_printing_id_printings_id_fk",
+          "tableFrom": "store_prices",
+          "tableTo": "printings",
+          "columnsFrom": [
+            "printing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "store_prices_store_id_stores_id_fk": {
+          "name": "store_prices_store_id_stores_id_fk",
+          "tableFrom": "store_prices",
+          "tableTo": "stores",
+          "columnsFrom": [
+            "store_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stores": {
+      "name": "stores",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scraper_enabled": {
+          "name": "scraper_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.unmatched_cards": {
+      "name": "unmatched_cards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "store_id": {
+          "name": "store_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_name": {
+          "name": "raw_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_set_name": {
+          "name": "raw_set_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_price": {
+          "name": "raw_price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scraped_at": {
+          "name": "scraped_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unmatched_cards_store_id_idx": {
+          "name": "unmatched_cards_store_id_idx",
+          "columns": [
+            {
+              "expression": "store_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "unmatched_cards_store_id_stores_id_fk": {
+          "name": "unmatched_cards_store_id_stores_id_fk",
+          "tableFrom": "unmatched_cards",
+          "tableTo": "stores",
+          "columnsFrom": [
+            "store_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/scraper/drizzle/meta/_journal.json
+++ b/apps/scraper/drizzle/meta/_journal.json
@@ -57,6 +57,20 @@
       "when": 1775784773113,
       "tag": "0007_wide_next_avengers",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1776240257521,
+      "tag": "0008_powerful_harpoon",
+      "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1776500000000,
+      "tag": "0009_set_value_aud",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/scraper/package.json
+++ b/apps/scraper/package.json
@@ -50,6 +50,7 @@
     "scrape:thecardhub": "tsx src/stores/run-store.ts the_card_hub_australia",
     "scrape:thatgamestore": "tsx src/stores/run-store.ts that_game_store",
     "scrape:area52": "tsx src/stores/run-store.ts area52",
+    "compute:set-values": "tsx src/stores/compute-set-values.ts",
     "test": "vitest run"
   },
   "dependencies": {

--- a/apps/scraper/src/lib/schema.ts
+++ b/apps/scraper/src/lib/schema.ts
@@ -1,6 +1,7 @@
 /**
  * Database schema — defines all tables using Drizzle ORM.
  *
+ *   sets            — one row per Scryfall set (set_code PK, set_type, parent_set_code)
  *   cards           — one row per unique MTG game object (oracle_id)
  *   printings       — one row per physical card version (scryfall card id)
  *   stores          — Australian retailers + eBay AU
@@ -25,11 +26,28 @@ import {
   serial,
   integer,
   date,
+  numeric,
 } from "drizzle-orm/pg-core";
 // Note: price_history is a PARTITIONED table (RANGE by recorded_at, monthly).
 // Drizzle does not model the partition structure — it sees the parent table only.
 // The id column was dropped as part of partitioning; natural key is
 // (printing_id, store_id, price_type, recorded_at).
+
+// ─── Sets ─────────────────────────────────────────────────────────────────────
+// One row per Scryfall set, populated by the Sets API during bulk import.
+// parent_set_code links child releases (Commander decks, Secret Lairs, promos)
+// back to their parent expansion. NULL = root set.
+
+export const sets = pgTable("sets", {
+  setCode: text("set_code").primaryKey(),                  // e.g. "ecl", "pecl"
+  setName: text("set_name").notNull(),
+  setType: text("set_type"),                               // nullable until first Scryfall import
+  parentSetCode: text("parent_set_code"),                  // NULL = root set
+  releasedAt: date("released_at").notNull(),
+  cardCount: integer("card_count").notNull().default(0),
+  iconSvgUri: text("icon_svg_uri"),
+  setValueAud: numeric("set_value_aud"),                   // updated after each nightly store scrape
+});
 
 // ─── Cards ────────────────────────────────────────────────────────────────────
 // One row per unique game object, keyed by Scryfall oracle_id.

--- a/apps/scraper/src/scryfall/bulk-import.ts
+++ b/apps/scraper/src/scryfall/bulk-import.ts
@@ -11,6 +11,7 @@ import { sql } from "drizzle-orm";
 import { db, schema } from "../lib/db.js";
 import { SCRYFALL_BULK_API_URL, SCRYFALL_OUTPUT_DIR, SCRYFALL_USER_AGENT, BATCH_SIZE } from "../lib/config.js";
 import { shouldImport, transform, type ScryfallCard } from "./transform.js";
+import { importSets } from "./sets-import.js";
 import { logger } from "../lib/logger.js";
 
 const log = logger.child({ component: "scryfall" });
@@ -61,6 +62,10 @@ async function fetchData(): Promise<void> {
 }
 
 async function importData(): Promise<void> {
+  // Populate sets table first so set_type + parent_set_code are available
+  // before any queries that join printings → sets.
+  await importSets();
+
   log.info("Reading saved Scryfall data");
   const raw = await readFile(OUTPUT_FILE, "utf-8");
   const allCards = JSON.parse(raw) as ScryfallCard[];

--- a/apps/scraper/src/scryfall/sets-import.ts
+++ b/apps/scraper/src/scryfall/sets-import.ts
@@ -1,0 +1,80 @@
+/**
+ * Scryfall Sets import — fetches all sets from the Scryfall Sets API and
+ * upserts them into the `sets` table.
+ *
+ * Called at the start of the bulk card import so that set metadata (set_type,
+ * parent_set_code) is available before printings are processed.
+ */
+
+import { sql } from "drizzle-orm";
+import { db, schema } from "../lib/db.js";
+import { SCRYFALL_USER_AGENT, BATCH_SIZE } from "../lib/config.js";
+import { logger } from "../lib/logger.js";
+
+const SCRYFALL_SETS_URL = "https://api.scryfall.com/sets";
+
+const log = logger.child({ component: "scryfall-sets" });
+
+interface ScryfallSetObject {
+  code: string;
+  name: string;
+  set_type: string;
+  parent_set_code?: string;
+  released_at: string;
+  card_count: number;
+  icon_svg_uri: string;
+  digital: boolean;
+}
+
+interface ScryfallSetsResponse {
+  object: "list";
+  has_more: boolean;
+  data: ScryfallSetObject[];
+}
+
+export async function importSets(): Promise<void> {
+  log.info("Fetching Scryfall sets list");
+
+  const res = await fetch(SCRYFALL_SETS_URL, {
+    headers: { "User-Agent": SCRYFALL_USER_AGENT },
+  });
+  if (!res.ok) throw new Error(`Scryfall Sets API request failed: ${res.status}`);
+
+  const body = (await res.json()) as ScryfallSetsResponse;
+  const allSets = body.data;
+
+  // Skip digital-only sets (e.g. MTGO treasure chests, Arena sets)
+  const sets = allSets.filter((s) => !s.digital);
+
+  log.info({ total: allSets.length, importing: sets.length }, "Upserting sets");
+
+  for (let i = 0; i < sets.length; i += BATCH_SIZE) {
+    const batch = sets.slice(i, i + BATCH_SIZE);
+    await db
+      .insert(schema.sets)
+      .values(
+        batch.map((s) => ({
+          setCode: s.code,
+          setName: s.name,
+          setType: s.set_type,
+          parentSetCode: s.parent_set_code ?? null,
+          releasedAt: s.released_at,
+          cardCount: s.card_count,
+          iconSvgUri: s.icon_svg_uri,
+        }))
+      )
+      .onConflictDoUpdate({
+        target: schema.sets.setCode,
+        set: {
+          setName: sql`excluded.set_name`,
+          setType: sql`excluded.set_type`,
+          parentSetCode: sql`excluded.parent_set_code`,
+          releasedAt: sql`excluded.released_at`,
+          cardCount: sql`excluded.card_count`,
+          iconSvgUri: sql`excluded.icon_svg_uri`,
+        },
+      });
+  }
+
+  log.info({ count: sets.length }, "Sets upserted");
+}

--- a/apps/scraper/src/stores/compute-set-values.ts
+++ b/apps/scraper/src/stores/compute-set-values.ts
@@ -1,0 +1,17 @@
+/**
+ * One-shot script: compute set_value_aud from current store_prices and write
+ * to sets table. Does NOT scrape any stores — uses whatever is already in DB.
+ *
+ * Run: pnpm --filter @mtg-au/scraper compute:set-values
+ */
+import { fileURLToPath } from "url";
+import { updateSetValues } from "./update-set-values.js";
+import { logger } from "../lib/logger.js";
+
+const log = logger.child({ component: "compute-set-values" });
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  updateSetValues()
+    .then(() => { log.info("Done"); process.exit(0); })
+    .catch((err) => { log.fatal({ err }, "Failed"); process.exit(1); });
+}

--- a/apps/scraper/src/stores/run-all.ts
+++ b/apps/scraper/src/stores/run-all.ts
@@ -26,6 +26,7 @@ import { SHOPIFY_STORES } from "./shopify-stores.config.js";
 import { seedStores } from "../seed.js";
 import type { BaseScraper } from "./base-scraper.js";
 import type { ScrapedCard } from "@mtg-au/shared";
+import { updateSetValues } from "./update-set-values.js";
 import { logger } from "../lib/logger.js";
 
 const log = logger.child({ component: "run-all" });
@@ -197,7 +198,12 @@ export async function runAllStores(): Promise<void> {
     }
   }
 
-  log.info("All stores done");
+  log.info("All stores done — computing set values");
+  try {
+    await updateSetValues();
+  } catch (err) {
+    log.error({ err }, "Set value update failed (non-fatal)");
+  }
 }
 
 // Only run when invoked directly (pnpm scrape:stores), not when imported by index.ts

--- a/apps/scraper/src/stores/update-set-values.ts
+++ b/apps/scraper/src/stores/update-set-values.ts
@@ -1,0 +1,70 @@
+/**
+ * Computes AU set values from current store_prices and writes them back to
+ * the sets table as set_value_aud.
+ *
+ * Value = sum of cheapest in-stock non-foil price per unique card, across the
+ * entire set family (root + non-token children). Basic lands excluded.
+ *
+ * Called once at the end of every nightly store scrape so the /sets listing
+ * can read a pre-computed value without any joins.
+ */
+
+import { sql } from "drizzle-orm";
+import { db } from "../lib/db.js";
+import { logger } from "../lib/logger.js";
+
+const log = logger.child({ component: "update-set-values" });
+
+export async function updateSetValues(): Promise<void> {
+  log.info("Computing set values from current store_prices");
+
+  // Single UPDATE: for each root set, sum the cheapest in-stock price per
+  // card across the full family (root + non-token children).
+  await db.execute(sql`
+    WITH family AS (
+      SELECT set_code AS root_code, set_code AS member_code
+      FROM sets WHERE parent_set_code IS NULL
+      UNION ALL
+      SELECT parent_set_code AS root_code, set_code AS member_code
+      FROM sets
+      WHERE parent_set_code IS NOT NULL
+        AND (set_type IS NULL OR set_type != 'token')
+    ),
+    card_min AS (
+      SELECT f.root_code, p.card_id, MIN(sp.price_aud::numeric) AS min_price
+      FROM family f
+      JOIN printings p ON p.set_code = f.member_code AND p.is_foil = false
+      JOIN cards c ON c.id = p.card_id
+      JOIN store_prices sp ON sp.printing_id = p.id
+      WHERE sp.in_stock = true
+        AND sp.price_type = 'sell'
+        AND c.type_line NOT ILIKE 'Basic Land%'
+      GROUP BY f.root_code, p.card_id
+    ),
+    totals AS (
+      SELECT root_code, SUM(min_price) AS total_value
+      FROM card_min
+      GROUP BY root_code
+    )
+    UPDATE sets
+    SET set_value_aud = totals.total_value
+    FROM totals
+    WHERE sets.set_code = totals.root_code
+  `);
+
+  // Zero out root sets that have no in-stock data (scrape may have cleared them)
+  await db.execute(sql`
+    UPDATE sets
+    SET set_value_aud = NULL
+    WHERE parent_set_code IS NULL
+      AND set_value_aud IS NOT NULL
+      AND NOT EXISTS (
+        SELECT 1 FROM store_prices sp
+        JOIN printings p ON p.id = sp.printing_id
+        WHERE p.set_code = sets.set_code
+          AND sp.in_stock = true AND sp.price_type = 'sell'
+      )
+  `);
+
+  log.info("Set values updated");
+}

--- a/apps/web/src/app/Breadcrumb.tsx
+++ b/apps/web/src/app/Breadcrumb.tsx
@@ -1,0 +1,24 @@
+type BreadcrumbItem = { label: string; href?: string };
+
+/**
+ * Shared breadcrumb trail.
+ * Items without `href` render as plain text (typically the current page).
+ */
+export function Breadcrumb({ items }: { items: BreadcrumbItem[] }) {
+  return (
+    <div className="text-[11px] text-cream-dim/40 mb-4">
+      {items.map((item, i) => (
+        <span key={i}>
+          {i > 0 && <span className="mx-1.5">›</span>}
+          {item.href ? (
+            <a href={item.href} className="hover:text-accent transition-colors">
+              {item.label}
+            </a>
+          ) : (
+            <span>{item.label}</span>
+          )}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/app/CardBreadcrumb.tsx
+++ b/apps/web/src/app/CardBreadcrumb.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { Breadcrumb } from "./Breadcrumb";
+
+/**
+ * Client-side breadcrumb for card pages.
+ * Reads ?from=<setCode>&fromName=<setName> from the URL so the breadcrumb
+ * always reflects the actual navigation context, regardless of ISR caching.
+ */
+export function CardBreadcrumb({ cardName }: { cardName: string }) {
+  const params = useSearchParams();
+  const fromCode = params.get("from");
+  const fromName = params.get("fromName");
+
+  if (fromCode) {
+    return (
+      <Breadcrumb items={[
+        { label: "Sets", href: "/sets" },
+        { label: fromName ?? fromCode.toUpperCase(), href: `/sets/${fromCode}` },
+        { label: cardName },
+      ]} />
+    );
+  }
+
+  return (
+    <Breadcrumb items={[
+      { label: "Search", href: "/" },
+      { label: cardName },
+    ]} />
+  );
+}

--- a/apps/web/src/app/CardMagnifier.tsx
+++ b/apps/web/src/app/CardMagnifier.tsx
@@ -6,38 +6,50 @@ interface Props {
   smallSrc: string;
   largeSrc: string;
   alt: string;
+  /** Milliseconds to wait before showing the popup. Defaults to 0 (immediate). */
+  delayMs?: number;
 }
 
-export function CardMagnifier({ smallSrc, largeSrc, alt }: Props) {
+export function CardMagnifier({ smallSrc, largeSrc, alt, delayMs = 0 }: Props) {
   const [show, setShow] = useState(false);
   const [pos, setPos] = useState({ top: 0, left: 0 });
   const wrapperRef = useRef<HTMLDivElement>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  function open() {
-    if (!wrapperRef.current) return;
+  function computePos() {
+    if (!wrapperRef.current) return null;
     const rect = wrapperRef.current.getBoundingClientRect();
     const popupW = 380;
-    const popupH = 530; // approx height of card at 380px wide
+    const popupH = 530;
 
-    // Prefer right side, fall back to left
     const spaceRight = window.innerWidth - rect.right;
     let left = spaceRight >= popupW + 16
       ? rect.right + 8
       : rect.left - popupW - 8;
-    // Clamp horizontally
     left = Math.max(8, Math.min(left, window.innerWidth - popupW - 8));
 
-    // Centre vertically on the thumbnail, clamp to viewport
-    // rect.top is already viewport-relative; fixed positioning needs viewport coords (no scrollY)
     const thumbMidY = rect.top + rect.height / 2;
     let top = thumbMidY - popupH / 2;
     top = Math.max(8, Math.min(top, window.innerHeight - popupH - 8));
 
-    setPos({ top, left });
-    setShow(true);
+    return { top, left };
+  }
+
+  function open() {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    if (delayMs > 0) {
+      timerRef.current = setTimeout(() => {
+        const p = computePos();
+        if (p) { setPos(p); setShow(true); }
+      }, delayMs);
+    } else {
+      const p = computePos();
+      if (p) { setPos(p); setShow(true); }
+    }
   }
 
   function close() {
+    if (timerRef.current) clearTimeout(timerRef.current);
     setShow(false);
   }
 

--- a/apps/web/src/app/CardThumb.tsx
+++ b/apps/web/src/app/CardThumb.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { CardMagnifier } from "./CardMagnifier";
+
+interface Props {
+  imageUri: string | null;
+  alt: string;
+  /** Tailwind classes that set the container size, e.g. "w-7 h-10" or "w-[44px] h-[61px] sm:w-[63px] sm:h-[88px]" */
+  className: string;
+  /** Delay before the magnifier popup appears. Defaults to 300ms. */
+  delayMs?: number;
+}
+
+function toSmallImage(uri: string): string {
+  return uri.replace("/normal/", "/small/");
+}
+
+/**
+ * Card thumbnail with hover magnifier. Pass the normal-sized Scryfall URI;
+ * the small variant is derived automatically. Size the thumbnail via className.
+ */
+export function CardThumb({ imageUri, alt, className, delayMs = 300 }: Props) {
+  if (!imageUri) {
+    return (
+      <div className={`rounded bg-muted flex items-center justify-center text-cream-dim/40 text-xs shrink-0 ${className}`}>
+        ?
+      </div>
+    );
+  }
+
+  return (
+    <div className={`rounded overflow-hidden shrink-0 ${className}`}>
+      <CardMagnifier
+        smallSrc={toSmallImage(imageUri)}
+        largeSrc={imageUri}
+        alt={alt}
+        delayMs={delayMs}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/app/SearchResults.tsx
+++ b/apps/web/src/app/SearchResults.tsx
@@ -4,8 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { CardThumb } from "./CardThumb";
 import { ColorSymbols } from "./ColorSymbols";
 import { TrendBadge } from "./TrendBadge";
-import { ViewToggle } from "./ViewToggle";
-import { useViewPreference } from "@/lib/hooks/useViewPreference";
+import { useViewPreference, type ViewMode } from "@/lib/hooks/useViewPreference";
 import { fmtAUD, cardHref, toSmallImage, trackEvent } from "@/lib/utils";
 import { MTG_CARD_ASPECT_RATIO } from "@/lib/config";
 import { useWantList } from "@/app/WantListContext";
@@ -77,6 +76,30 @@ function AddToWantListButton({ card }: { card: CardSearchResult }) {
     >
       {alreadyAdded ? "✓" : adding ? "…" : "+"}
     </button>
+  );
+}
+
+function SearchViewToggle({ view, onChange }: { view: ViewMode; onChange: (v: ViewMode) => void }) {
+  const options: { mode: ViewMode; label: string; title: string }[] = [
+    { mode: "grid", label: "⊞", title: "Grid view" },
+    { mode: "card", label: "▤", title: "Card view" },
+    { mode: "text", label: "☰", title: "Text view" },
+  ];
+  return (
+    <div className="flex items-center gap-0.5 rounded-lg border border-subtle bg-muted p-0.5">
+      {options.map(({ mode, label, title }) => (
+        <button
+          key={mode}
+          onClick={() => onChange(mode)}
+          title={title}
+          className={`rounded px-2 py-1 text-sm transition-colors ${
+            view === mode ? "bg-surface text-cream shadow-sm" : "text-cream-dim/50 hover:text-cream-dim"
+          }`}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
   );
 }
 
@@ -204,13 +227,7 @@ function TextRow({ card }: { card: CardSearchResult }) {
           <ColorSymbols colors={card.colors} size={11} />
         </div>
         <div className="flex-1 min-w-0">
-          {card.image_uri ? (
-            <HoverCardPopup imageSrc={card.image_uri} alt={card.name} delay={500}>
-              <span className="font-medium text-cream">{card.name}</span>
-            </HoverCardPopup>
-          ) : (
-            <span className="font-medium text-cream">{card.name}</span>
-          )}
+          <span className="font-medium text-cream">{card.name}</span>
           <span className="ml-2 text-xs text-cream-dim/60 hidden sm:inline">{card.type_line}</span>
         </div>
         <div className="flex items-center gap-2 shrink-0">
@@ -288,7 +305,7 @@ export function SearchResults({ initialResults, query, initialHasMore, totalCoun
         <p className="text-sm text-cream-dim/70">
           {totalCount} result{totalCount !== 1 ? "s" : ""}
         </p>
-        <ViewToggle view={view} onChange={setView} />
+        <SearchViewToggle view={view} onChange={setView} />
       </div>
 
       {/* Grid view */}

--- a/apps/web/src/app/SearchResults.tsx
+++ b/apps/web/src/app/SearchResults.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { CardMagnifier } from "./CardMagnifier";
+import { CardThumb } from "./CardThumb";
 import { ColorSymbols } from "./ColorSymbols";
 import { TrendBadge } from "./TrendBadge";
 import { fmtAUD, cardHref } from "@/lib/utils";
@@ -14,9 +14,6 @@ declare global {
   }
 }
 
-function toSmallImage(uri: string | null): string | null {
-  return uri ? uri.replace("/normal/", "/small/") : null;
-}
 
 function AddToWantListButton({ card }: { card: CardSearchResult }) {
   const { items, addItem } = useWantList();
@@ -90,7 +87,6 @@ function AddToWantListButton({ card }: { card: CardSearchResult }) {
 }
 
 function CardRow({ card }: { card: CardSearchResult }) {
-  const thumb = toSmallImage(card.image_uri);
   return (
     <div className="relative flex items-center rounded-lg border border-subtle bg-surface hover:border-accent hover:bg-muted transition-colors overflow-hidden">
       <a
@@ -99,13 +95,12 @@ function CardRow({ card }: { card: CardSearchResult }) {
         className="flex flex-1 items-center gap-3 min-w-0 pr-14"
       >
         {/* Thumbnail */}
-        <div className="shrink-0 w-[44px] h-[61px] sm:w-[63px] sm:h-[88px] bg-muted overflow-hidden">
-          {thumb && card.image_uri ? (
-            <CardMagnifier smallSrc={thumb} largeSrc={card.image_uri} alt={card.name} />
-          ) : (
-            <div className="w-full h-full flex items-center justify-center text-cream-dim/40 text-xs">?</div>
-          )}
-        </div>
+        <CardThumb
+          imageUri={card.image_uri}
+          alt={card.name}
+          className="w-[44px] h-[61px] sm:w-[63px] sm:h-[88px]"
+          delayMs={0}
+        />
 
         {/* Info */}
         <div className="flex flex-1 items-center justify-between gap-2 min-w-0">

--- a/apps/web/src/app/SetSymbol.tsx
+++ b/apps/web/src/app/SetSymbol.tsx
@@ -3,7 +3,21 @@
 import { useState, type SyntheticEvent } from "react";
 import { RARITY_FILTER, RARITY_FALLBACK_COLOR } from "@/lib/rarity";
 
-export function SetSymbol({ setCode, setName, rarity }: { setCode: string; setName: string; rarity: string }) {
+interface SetSymbolProps {
+  setCode: string;
+  setName: string;
+  rarity?: string;
+  size?: number;
+  className?: string;
+}
+
+export function SetSymbol({
+  setCode,
+  setName,
+  rarity = "rare",
+  size = 18,
+  className = "shrink-0",
+}: SetSymbolProps) {
   const [failed, setFailed] = useState(false);
   const color = RARITY_FALLBACK_COLOR[rarity] ?? RARITY_FALLBACK_COLOR.common;
 
@@ -14,7 +28,10 @@ export function SetSymbol({ setCode, setName, rarity }: { setCode: string; setNa
 
   if (failed) {
     return (
-      <span style={{ color, fontSize: 14, width: 18, textAlign: "center", display: "inline-block" }} title={setName}>
+      <span
+        style={{ color, fontSize: size * 0.8, width: size, textAlign: "center", display: "inline-block" }}
+        title={setName}
+      >
         ❖
       </span>
     );
@@ -25,9 +42,9 @@ export function SetSymbol({ setCode, setName, rarity }: { setCode: string; setNa
     <img
       src={`https://svgs.scryfall.io/sets/${setCode}.svg`}
       alt={setName}
-      width={18}
-      height={18}
-      className="shrink-0"
+      width={size}
+      height={size}
+      className={className}
       style={{ filter: RARITY_FILTER[rarity] ?? RARITY_FILTER.common }}
       loading="lazy"
       onError={onError}

--- a/apps/web/src/app/ViewToggle.tsx
+++ b/apps/web/src/app/ViewToggle.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+export type ViewMode = "medium" | "compact";
+
+interface ViewToggleProps {
+  value: ViewMode;
+  onChange: (mode: ViewMode) => void;
+}
+
+const OPTIONS: { mode: ViewMode; label: string; title: string }[] = [
+  { mode: "medium", label: "⊞", title: "Grid view" },
+  { mode: "compact", label: "☰", title: "Compact view" },
+];
+
+export function ViewToggle({ value, onChange }: ViewToggleProps) {
+  return (
+    <div className="flex items-center gap-0.5 rounded-lg border border-subtle bg-muted p-0.5">
+      {OPTIONS.map(({ mode, label, title }) => (
+        <button
+          key={mode}
+          onClick={() => onChange(mode)}
+          title={title}
+          className={`rounded px-2 py-1 text-sm transition-colors ${
+            value === mode
+              ? "bg-surface text-cream shadow-sm"
+              : "text-cream-dim/50 hover:text-cream-dim"
+          }`}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/app/cards/[slug]/page.tsx
+++ b/apps/web/src/app/cards/[slug]/page.tsx
@@ -2,9 +2,12 @@ export const revalidate = 3600;
 
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
+import { Suspense } from "react";
 import { getCard, getCardMetadata, getPrintingsWithPrices, getCardTrend, getCardPriceHistory, type PrintingWithPrices } from "@/lib/db";
 import { getAudPerUsd } from "@/lib/exchange-rate";
 import { CardDetailView } from "./CardDetailView";
+import { CardBreadcrumb } from "@/app/CardBreadcrumb";
+import { Breadcrumb } from "@/app/Breadcrumb";
 
 function sortPrintings(printings: PrintingWithPrices[]): PrintingWithPrices[] {
   return [...printings].sort((a, b) => {
@@ -62,7 +65,6 @@ export default async function CardPage({
   params,
 }: {
   params: Promise<{ slug: string }>;
-  searchParams: Promise<Record<string, string>>;
 }) {
   const { slug } = await params;
 
@@ -111,12 +113,9 @@ export default async function CardPage({
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
-      <a
-        href="/"
-        className="mb-5 inline-flex items-center gap-1 text-sm text-accent hover:text-accent-light transition-colors"
-      >
-        ← Back to search
-      </a>
+      <Suspense fallback={<Breadcrumb items={[{ label: "Search", href: "/" }, { label: card!.name }]} />}>
+        <CardBreadcrumb cardName={card!.name} />
+      </Suspense>
       <CardDetailView card={card!} cardSlug={slug} printings={printings} trend={trend} history={history} audPerUsd={audPerUsd} />
     </div>
   );

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -79,6 +79,7 @@ export default function RootLayout({
                 <span className="sm:hidden">© {new Date().getFullYear()} Scrymarket</span>
               </p>
               <nav className="flex flex-wrap gap-x-3 gap-y-1">
+                <a href="/sets" className="hover:text-accent transition-colors">Sets</a>
                 <a href="/about" className="hover:text-accent transition-colors">About</a>
                 <a href="/faq" className="hover:text-accent transition-colors">FAQ</a>
                 <a href="/contact" className="hover:text-accent transition-colors">Contact</a>

--- a/apps/web/src/app/sets/MarketPulse.tsx
+++ b/apps/web/src/app/sets/MarketPulse.tsx
@@ -113,10 +113,7 @@ export function MarketPulse({
     <div className="rounded-xl border border-subtle bg-surface p-5 mb-8">
       <div className="flex items-center justify-between mb-4">
         <div>
-          <h1 className="text-lg font-bold text-cream">AU MTG Price Tracker</h1>
-          <p className="text-[12px] text-cream-dim/50 mt-0.5">
-            Biggest price movements across Australian stores
-          </p>
+          <h1 className="text-lg font-bold text-cream">Big movers</h1>
         </div>
         <WindowToggle value={window} onChange={setWindow} />
       </div>

--- a/apps/web/src/app/sets/MarketPulse.tsx
+++ b/apps/web/src/app/sets/MarketPulse.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useState } from "react";
+import type { TopMover } from "@/lib/db";
+import { cardHref } from "@/lib/utils";
+import { CardThumb } from "@/app/CardThumb";
+
+type Window = 7 | 14 | 30;
+
+function fmtAUD(n: number) {
+  return `$${n.toFixed(2)}`;
+}
+
+function MoverRow({ m, rank }: { m: TopMover; rank: number }) {
+  const pct = parseFloat(m.pct_change);
+  const from = parseFloat(m.start_price);
+  const to = parseFloat(m.current_price);
+  const isUp = m.direction === "up";
+
+  return (
+    <a
+      href={cardHref(m.slug, m.card_id, { code: m.set_code, name: m.set_name })}
+      className="group flex items-center gap-3 px-3 py-2 hover:bg-muted/50 transition-colors rounded-lg"
+    >
+      <span className="text-[11px] font-bold text-cream-dim/25 w-4 shrink-0 text-center">
+        {rank}
+      </span>
+
+      <CardThumb imageUri={m.image_uri} alt={m.name} className="w-8 h-11" />
+
+      <div className="min-w-0 flex-1">
+        <div className="text-xs font-semibold text-cream truncate group-hover:text-accent transition-colors">
+          {m.name}
+        </div>
+        <div className="text-[10px] text-cream-dim/40 truncate">{m.set_name}</div>
+      </div>
+
+      <div className="text-right shrink-0">
+        <div className={`text-sm font-black tabular-nums ${isUp ? "text-green-400" : "text-red-400"}`}>
+          {isUp ? "+" : ""}{pct.toFixed(0)}%
+        </div>
+        <div className="text-[10px] text-cream-dim/40 tabular-nums">
+          {fmtAUD(from)} → {fmtAUD(to)}
+        </div>
+      </div>
+    </a>
+  );
+}
+
+function Leaderboard({ movers, direction }: { movers: TopMover[]; direction: "up" | "down" }) {
+  if (movers.length === 0) return null;
+  const isUp = direction === "up";
+
+  return (
+    <div className="flex-1 min-w-0 rounded-xl border border-subtle bg-surface overflow-hidden">
+      <div className={`flex items-center gap-2 px-3 py-2 border-b border-subtle ${
+        isUp ? "bg-green-950/30" : "bg-red-950/30"
+      }`}>
+        <span className={`text-xs font-bold ${isUp ? "text-green-400" : "text-red-400"}`}>
+          {isUp ? "▲" : "▼"}
+        </span>
+        <span className="text-[11px] font-semibold text-cream uppercase tracking-wider">
+          {isUp ? "Biggest Gains" : "Biggest Drops"}
+        </span>
+      </div>
+      <div className="py-1 divide-y divide-subtle/20">
+        {movers.map((m, i) => (
+          <MoverRow key={m.card_id} m={m} rank={i + 1} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function WindowToggle({ value, onChange }: { value: Window; onChange: (w: Window) => void }) {
+  const options: Window[] = [7, 14, 30];
+  return (
+    <div className="flex items-center rounded-md border border-subtle overflow-hidden">
+      {options.map((w) => (
+        <button
+          key={w}
+          onClick={() => onChange(w)}
+          className={`px-2.5 py-1 text-[11px] font-medium transition-colors ${
+            value === w
+              ? "bg-accent/20 text-accent"
+              : "text-cream-dim/40 hover:text-cream-dim hover:bg-muted"
+          }`}
+        >
+          {w}d
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export function MarketPulse({
+  movers7,
+  movers14,
+  movers30,
+}: {
+  movers7: TopMover[];
+  movers14: TopMover[];
+  movers30: TopMover[];
+}) {
+  const [window, setWindow] = useState<Window>(7);
+  const movers = window === 7 ? movers7 : window === 14 ? movers14 : movers30;
+
+  const up = movers.filter((m) => m.direction === "up");
+  const down = movers.filter((m) => m.direction === "down");
+  const hasData = up.length > 0 || down.length > 0;
+
+  return (
+    <div className="rounded-xl border border-subtle bg-surface p-5 mb-8">
+      <div className="flex items-center justify-between mb-4">
+        <div>
+          <h1 className="text-lg font-bold text-cream">AU MTG Price Tracker</h1>
+          <p className="text-[12px] text-cream-dim/50 mt-0.5">
+            Biggest price movements across Australian stores
+          </p>
+        </div>
+        <WindowToggle value={window} onChange={setWindow} />
+      </div>
+
+      {!hasData ? (
+        <p className="text-sm text-cream-dim/40 py-2">
+          Not enough price history yet — check back after a few scrape runs.
+        </p>
+      ) : (
+        <div className="flex flex-col sm:flex-row gap-3">
+          <Leaderboard movers={up} direction="up" />
+          <Leaderboard movers={down} direction="down" />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/sets/SetsListClient.tsx
+++ b/apps/web/src/app/sets/SetsListClient.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import { useState } from "react";
+import { SetSymbol } from "@/app/SetSymbol";
+import { ViewToggle, type ViewMode } from "@/app/ViewToggle";
+import type { SetSummary } from "@/lib/db";
+
+function formatDate(dateStr: string) {
+  return new Date(dateStr).toLocaleDateString("en-AU", {
+    month: "short",
+    year: "numeric",
+  });
+}
+
+function isNew(dateStr: string, days = 60) {
+  return Date.now() - new Date(dateStr).getTime() < days * 86_400_000;
+}
+
+const CHILD_TYPE_LABEL: Record<string, string> = {
+  commander:       "Commander",
+  promo:           "Promo",
+  memorabilia:     "Secret Lair",
+  box:             "Box Toppers",
+  draft_innovation:"Bonus Sheet",
+  masters:         "Masters",
+};
+
+function SubsetBadges({ childTypes }: { childTypes: string | null }) {
+  if (!childTypes) return null;
+  const labels = childTypes
+    .split(",")
+    .map((t) => CHILD_TYPE_LABEL[t])
+    .filter(Boolean);
+  if (labels.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap gap-1 mt-2">
+      {labels.map((label) => (
+        <span
+          key={label}
+          className="text-[9px] uppercase tracking-wider px-1.5 py-0.5 rounded border border-accent/20 text-accent/60 bg-accent-muted/30"
+        >
+          {label}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function SetCardMedium({ set }: { set: SetSummary }) {
+  const fresh = isNew(set.released_at);
+  const value = set.set_value_aud ? parseFloat(set.set_value_aud) : null;
+
+  return (
+    <a
+      href={`/sets/${set.set_code}`}
+      className="group relative block rounded-lg border border-subtle bg-surface p-4 hover:border-accent-border hover:bg-accent-muted transition-colors"
+    >
+      {fresh && (
+        <span className="absolute top-3 right-3 text-[9px] uppercase tracking-widest font-semibold text-accent bg-accent-muted border border-accent/30 rounded px-1.5 py-0.5">
+          New
+        </span>
+      )}
+
+      <div className="flex items-start gap-3">
+        <SetSymbol
+          setCode={set.set_code}
+          setName={set.set_name}
+          size={32}
+          className="shrink-0 mt-0.5 opacity-70 group-hover:opacity-100 transition-opacity"
+        />
+        <div className="min-w-0 flex-1">
+          <div className="font-medium text-cream text-sm leading-tight truncate pr-8">
+            {set.set_name}
+          </div>
+          <div className="text-[11px] text-cream-dim/50 mt-0.5 uppercase tracking-wide">
+            {set.set_code} · {formatDate(set.released_at)}
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-3 flex items-end justify-between">
+        <div>
+          <div className="text-[10px] text-cream-dim/40 uppercase tracking-wider">Set value</div>
+          <div className="text-lg font-bold text-price">
+            {value != null ? `$${value.toFixed(0)}` : "—"}
+            {value != null && <span className="text-[10px] text-cream-dim/40 font-normal ml-1">AUD</span>}
+          </div>
+        </div>
+        <div className="text-right">
+          <div className="text-[10px] text-cream-dim/40 uppercase tracking-wider">Cards</div>
+          <div className="text-sm font-semibold text-cream-dim">{set.card_count}</div>
+        </div>
+      </div>
+
+      <SubsetBadges childTypes={set.child_types} />
+    </a>
+  );
+}
+
+function SetRowCompact({ set }: { set: SetSummary }) {
+  const fresh = isNew(set.released_at);
+  const value = set.set_value_aud ? parseFloat(set.set_value_aud) : null;
+  const childLabels = set.child_types
+    ? set.child_types.split(",").map((t) => CHILD_TYPE_LABEL[t]).filter(Boolean)
+    : [];
+
+  return (
+    <a
+      href={`/sets/${set.set_code}`}
+      className="group flex items-center gap-3 px-3 py-2 rounded-lg border border-subtle bg-surface hover:border-accent-border hover:bg-accent-muted transition-colors"
+    >
+      <SetSymbol
+        setCode={set.set_code}
+        setName={set.set_name}
+        size={20}
+        className="shrink-0 opacity-70 group-hover:opacity-100 transition-opacity"
+      />
+      <div className="min-w-0 flex-1 flex items-center gap-2">
+        <span className="text-sm font-medium text-cream truncate">{set.set_name}</span>
+        {fresh && (
+          <span className="text-[8px] uppercase tracking-widest font-semibold text-accent border border-accent/30 rounded px-1 py-0.5 shrink-0">
+            New
+          </span>
+        )}
+      </div>
+      <div className="text-[11px] text-cream-dim/40 uppercase tracking-wide shrink-0 hidden sm:block">
+        {set.set_code}
+      </div>
+      <div className="text-[11px] text-cream-dim/40 shrink-0 hidden md:block w-16 text-right">
+        {formatDate(set.released_at)}
+      </div>
+      {childLabels.length > 0 && (
+        <div className="hidden lg:flex gap-1 shrink-0">
+          {childLabels.slice(0, 2).map((label) => (
+            <span
+              key={label}
+              className="text-[9px] uppercase tracking-wider px-1.5 py-0.5 rounded border border-accent/20 text-accent/60 bg-accent-muted/30"
+            >
+              {label}
+            </span>
+          ))}
+          {childLabels.length > 2 && (
+            <span className="text-[9px] text-cream-dim/30">+{childLabels.length - 2}</span>
+          )}
+        </div>
+      )}
+      <div className="text-sm font-semibold text-price shrink-0 w-16 text-right">
+        {value != null ? `$${value.toFixed(0)}` : "—"}
+      </div>
+      <div className="text-xs text-cream-dim/40 shrink-0 w-8 text-right">
+        {set.card_count}
+      </div>
+    </a>
+  );
+}
+
+export function SetsListClient({
+  sets,
+  showAll,
+}: {
+  sets: SetSummary[];
+  showAll: boolean;
+}) {
+  const [view, setView] = useState<ViewMode>("medium");
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-4">
+        <p className="text-sm text-cream-dim/60">
+          {showAll
+            ? `${sets.length} sets — click any set for AU price data`
+            : `${sets.length} sets from the last 2 years — click for AU price data`}
+        </p>
+        <ViewToggle value={view} onChange={setView} />
+      </div>
+
+      {view === "medium" ? (
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {sets.map((set) => (
+            <SetCardMedium key={set.set_code} set={set} />
+          ))}
+        </div>
+      ) : (
+        <div className="space-y-1.5">
+          <div className="flex items-center gap-3 px-3 pb-1 text-[10px] text-cream-dim/30 uppercase tracking-wider">
+            <div className="w-5 shrink-0" />
+            <div className="flex-1">Set</div>
+            <div className="hidden sm:block w-10 text-right">Code</div>
+            <div className="hidden md:block w-16 text-right">Released</div>
+            <div className="hidden lg:block w-auto text-right">Subsets</div>
+            <div className="w-16 text-right">Value</div>
+            <div className="w-8 text-right">Cards</div>
+          </div>
+          {sets.map((set) => (
+            <SetRowCompact key={set.set_code} set={set} />
+          ))}
+        </div>
+      )}
+
+      {!showAll && (
+        <div className="mt-6 text-center">
+          <a
+            href="/sets?all=1"
+            className="text-sm text-cream-dim/50 hover:text-cream-dim transition-colors border border-subtle rounded-lg px-4 py-2 inline-block hover:border-accent/40"
+          >
+            Show older sets
+          </a>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/sets/[setCode]/CrashCurveChart.tsx
+++ b/apps/web/src/app/sets/[setCode]/CrashCurveChart.tsx
@@ -1,0 +1,225 @@
+"use client";
+
+import { useMemo } from "react";
+import {
+  ResponsiveContainer,
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ReferenceLine,
+} from "recharts";
+import type { SetPriceTimelinePoint } from "@/lib/db";
+import { fmtAUD } from "@/lib/utils";
+
+function formatDate(dateStr: string) {
+  const d = new Date(dateStr);
+  return d.toLocaleDateString("en-AU", { day: "numeric", month: "short" });
+}
+
+const tooltipStyle = {
+  backgroundColor: "var(--color-surface, #1a1a1a)",
+  border: "1px solid var(--color-subtle, #333)",
+  borderRadius: 6,
+  fontSize: 11,
+  color: "var(--color-cream, #f0e8d8)",
+};
+const tickStyle = {
+  fill: "var(--color-cream-dim, #a09880)",
+  fontSize: 9,
+  opacity: 0.6,
+};
+
+interface InsightStats {
+  peakValue: number;
+  peakDate: string;
+  currentValue: number;
+  firstValue: number;
+  totalChangePct: number;
+  weekOneSaved: number | null;
+}
+
+function computeInsights(timeline: SetPriceTimelinePoint[]): InsightStats | null {
+  if (timeline.length < 2) return null;
+
+  const values = timeline.map((t) => parseFloat(t.total_value));
+  const firstValue = values[0];
+  const currentValue = values[values.length - 1];
+  const peakValue = Math.max(...values);
+  const peakIdx = values.indexOf(peakValue);
+  const peakDate = timeline[peakIdx].date;
+  const totalChangePct = firstValue > 0 ? ((currentValue - firstValue) / firstValue) * 100 : 0;
+
+  // "Waited 6 weeks" saving: compare week 1 average vs week 6 value
+  let weekOneSaved: number | null = null;
+  if (timeline.length >= 42) {
+    const week6Value = values[41]; // ~6 weeks of daily data
+    weekOneSaved = firstValue - week6Value;
+  }
+
+  return { peakValue, peakDate, currentValue, firstValue, totalChangePct, weekOneSaved };
+}
+
+export function CrashCurveChart({
+  timeline,
+}: {
+  timeline: SetPriceTimelinePoint[];
+}) {
+  const chartData = useMemo(
+    () => timeline.map((t) => ({ date: t.date, value: parseFloat(t.total_value) })),
+    [timeline]
+  );
+
+  const insights = useMemo(() => computeInsights(timeline), [timeline]);
+
+  const yDomain = useMemo(() => {
+    const values = chartData.map((d) => d.value);
+    const min = Math.min(...values);
+    const max = Math.max(...values);
+    const pad = (max - min) * 0.12 || 10;
+    return [Math.max(0, min - pad), max + pad] as [number, number];
+  }, [chartData]);
+
+  const crashed = insights && insights.totalChangePct < -5;
+  const stable = insights && Math.abs(insights.totalChangePct) <= 5;
+
+  return (
+    <div className="space-y-4">
+      {/* Insight callout */}
+      {insights && (
+        <div className="rounded-lg border border-subtle bg-surface px-4 py-3 flex flex-wrap gap-4 text-sm">
+          <Stat
+            label="Release value"
+            value={fmtAUD(insights.firstValue)}
+          />
+          <Stat
+            label="Current value"
+            value={fmtAUD(insights.currentValue)}
+            highlight
+          />
+          <Stat
+            label="Change"
+            value={`${insights.totalChangePct > 0 ? "+" : ""}${insights.totalChangePct.toFixed(1)}%`}
+            color={
+              insights.totalChangePct < -5
+                ? "text-green-400"
+                : insights.totalChangePct > 5
+                ? "text-red-400"
+                : "text-cream-dim"
+            }
+          />
+          {insights.weekOneSaved != null && insights.weekOneSaved > 0 && (
+            <Stat
+              label="Saved by waiting 6 weeks"
+              value={fmtAUD(insights.weekOneSaved)}
+              color="text-green-400"
+            />
+          )}
+        </div>
+      )}
+
+      {/* Narrative caption */}
+      {insights && (
+        <p className="text-[11px] text-cream-dim/50 leading-relaxed">
+          {crashed
+            ? `Total set value has dropped ${Math.abs(insights.totalChangePct).toFixed(0)}% since release — the typical new-set depreciation curve as hype gives way to supply.`
+            : stable
+            ? `Prices have held relatively steady since release, suggesting strong demand matching supply.`
+            : `Set value has risen ${insights.totalChangePct.toFixed(0)}% since release — unusual for a new set.`}
+          {insights.weekOneSaved != null && insights.weekOneSaved > 1
+            ? ` Buyers who waited just 6 weeks saved ~${fmtAUD(insights.weekOneSaved)} on a full set.`
+            : null}
+        </p>
+      )}
+
+      {/* Chart */}
+      <div className="rounded-lg border border-subtle bg-surface overflow-hidden">
+        <ResponsiveContainer width="100%" height={260}>
+          <AreaChart data={chartData} margin={{ top: 12, right: 8, bottom: 0, left: -4 }}>
+            <defs>
+              <linearGradient id="crashGrad" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor="#FD8B51" stopOpacity={0.25} />
+                <stop offset="95%" stopColor="#FD8B51" stopOpacity={0} />
+              </linearGradient>
+            </defs>
+            <XAxis
+              dataKey="date"
+              tickFormatter={formatDate}
+              tick={tickStyle}
+              tickLine={false}
+              axisLine={false}
+              interval="preserveStartEnd"
+              minTickGap={60}
+            />
+            <YAxis
+              domain={yDomain}
+              tickFormatter={(v) => `$${(v / 1000).toFixed(v >= 1000 ? 1 : 0)}${v >= 1000 ? "k" : ""}`}
+              tick={tickStyle}
+              tickLine={false}
+              axisLine={false}
+              width={36}
+            />
+            <Tooltip
+              contentStyle={tooltipStyle}
+              formatter={((value: number) => [fmtAUD(value), "Set value"]) as never}
+              labelFormatter={formatDate as never}
+            />
+            {/* Reference line at release (day 1) */}
+            {chartData.length > 0 && (
+              <ReferenceLine
+                x={chartData[0].date}
+                stroke="var(--color-subtle, #3d3a33)"
+                strokeDasharray="3 3"
+                label={{
+                  value: "Release",
+                  position: "insideTopRight",
+                  fontSize: 9,
+                  fill: "var(--color-cream-dim, #a89d8a)",
+                  opacity: 0.6,
+                }}
+              />
+            )}
+            <Area
+              type="monotone"
+              dataKey="value"
+              stroke="#FD8B51"
+              strokeWidth={1.5}
+              fill="url(#crashGrad)"
+              dot={false}
+            />
+          </AreaChart>
+        </ResponsiveContainer>
+      </div>
+
+      {/* X-axis label */}
+      {timeline.length > 0 && (
+        <div className="flex justify-between text-[10px] text-cream-dim/30 px-1">
+          <span>{formatDate(timeline[0].date)}</span>
+          <span>{formatDate(timeline[timeline.length - 1].date)}</span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  highlight,
+  color,
+}: {
+  label: string;
+  value: string;
+  highlight?: boolean;
+  color?: string;
+}) {
+  return (
+    <div>
+      <div className="text-[10px] text-cream-dim/40 uppercase tracking-wider">{label}</div>
+      <div className={`font-semibold ${highlight ? "text-price" : (color ?? "text-cream")}`}>
+        {value}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/sets/[setCode]/CrashCurveChart.tsx
+++ b/apps/web/src/app/sets/[setCode]/CrashCurveChart.tsx
@@ -10,7 +10,7 @@ import {
   Tooltip,
   ReferenceLine,
 } from "recharts";
-import type { SetPriceTimelinePoint } from "@/lib/db";
+import type { SetPriceTimelinePoint, SetRarityBreakdown } from "@/lib/db";
 import { fmtAUD } from "@/lib/utils";
 
 function formatDate(dateStr: string) {
@@ -61,10 +61,19 @@ function computeInsights(timeline: SetPriceTimelinePoint[]): InsightStats | null
   return { peakValue, peakDate, currentValue, firstValue, totalChangePct, weekOneSaved };
 }
 
+const RARITY_STYLE: Record<string, { label: string; color: string; bg: string; border: string }> = {
+  mythic:   { label: "Mythic",   color: "#b5642a", bg: "bg-orange-900/20", border: "border-orange-900/30" },
+  rare:     { label: "Rare",     color: "#a8894a", bg: "bg-yellow-900/20", border: "border-yellow-900/30" },
+  uncommon: { label: "Uncommon", color: "#8aa7b8", bg: "bg-blue-900/20",   border: "border-blue-900/40" },
+  common:   { label: "Common",   color: "#888888", bg: "bg-muted",         border: "border-subtle" },
+};
+
 export function CrashCurveChart({
   timeline,
+  rarityBreakdown = [],
 }: {
   timeline: SetPriceTimelinePoint[];
+  rarityBreakdown?: SetRarityBreakdown[];
 }) {
   const chartData = useMemo(
     () => timeline.map((t) => ({ date: t.date, value: parseFloat(t.total_value) })),
@@ -197,6 +206,34 @@ export function CrashCurveChart({
         <div className="flex justify-between text-[10px] text-cream-dim/30 px-1">
           <span>{formatDate(timeline[0].date)}</span>
           <span>{formatDate(timeline[timeline.length - 1].date)}</span>
+        </div>
+      )}
+
+      {/* Rarity breakdown — overlaid below the chart */}
+      {rarityBreakdown.length > 0 && (
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 pt-1">
+          {rarityBreakdown.map((r) => {
+            const style = RARITY_STYLE[r.rarity];
+            if (!style) return null;
+            const avg = r.avg_price ? parseFloat(r.avg_price) : null;
+            return (
+              <div
+                key={r.rarity}
+                className={`rounded-lg border ${style.border} ${style.bg} px-3 py-2`}
+              >
+                <div className="flex items-center gap-1.5 mb-0.5">
+                  <span className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: style.color }} />
+                  <span className="text-[10px] uppercase tracking-wider text-cream-dim/60">{style.label}</span>
+                </div>
+                <div className="text-sm font-bold text-cream">
+                  {avg != null ? fmtAUD(avg) : "—"}
+                </div>
+                <div className="text-[10px] text-cream-dim/40">
+                  avg · {r.card_count} card{r.card_count !== 1 ? "s" : ""}
+                </div>
+              </div>
+            );
+          })}
         </div>
       )}
     </div>

--- a/apps/web/src/app/sets/[setCode]/RarityBreakdown.tsx
+++ b/apps/web/src/app/sets/[setCode]/RarityBreakdown.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { useMemo } from "react";
+import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip, Cell } from "recharts";
+import type { SetRarityBreakdown } from "@/lib/db";
+import { fmtAUD } from "@/lib/utils";
+
+const RARITY_STYLE: Record<
+  string,
+  { label: string; color: string; bg: string; border: string }
+> = {
+  mythic: {
+    label: "Mythic",
+    color: "#b5642a",
+    bg: "bg-orange-900/20",
+    border: "border-orange-900/30",
+  },
+  rare: {
+    label: "Rare",
+    color: "#a8894a",
+    bg: "bg-yellow-900/20",
+    border: "border-yellow-900/30",
+  },
+  uncommon: {
+    label: "Uncommon",
+    color: "#8aa7b8",
+    bg: "bg-blue-900/20",
+    border: "border-blue-900/30",
+  },
+  common: {
+    label: "Common",
+    color: "#888888",
+    bg: "bg-muted",
+    border: "border-subtle",
+  },
+};
+
+const tooltipStyle = {
+  backgroundColor: "var(--color-surface, #1a1a1a)",
+  border: "1px solid var(--color-subtle, #333)",
+  borderRadius: 6,
+  fontSize: 11,
+  color: "var(--color-cream, #f0e8d8)",
+};
+
+export function RarityBreakdown({
+  breakdown,
+}: {
+  breakdown: SetRarityBreakdown[];
+}) {
+  const totalValue = useMemo(
+    () =>
+      breakdown.reduce(
+        (sum, r) => sum + (r.total_value ? parseFloat(r.total_value) : 0),
+        0
+      ),
+    [breakdown]
+  );
+
+  const chartData = useMemo(
+    () =>
+      breakdown.map((r) => ({
+        rarity: RARITY_STYLE[r.rarity]?.label ?? r.rarity,
+        key: r.rarity,
+        avg: r.avg_price ? parseFloat(r.avg_price) : 0,
+        total: r.total_value ? parseFloat(r.total_value) : 0,
+        count: r.card_count,
+      })),
+    [breakdown]
+  );
+
+  return (
+    <div className="space-y-4">
+      {/* Stat cards */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        {breakdown.map((r) => {
+          const style = RARITY_STYLE[r.rarity];
+          if (!style) return null;
+          const avg = r.avg_price ? parseFloat(r.avg_price) : null;
+          const total = r.total_value ? parseFloat(r.total_value) : null;
+          const pct = total != null && totalValue > 0 ? (total / totalValue) * 100 : 0;
+
+          return (
+            <div
+              key={r.rarity}
+              className={`rounded-lg border ${style.border} ${style.bg} px-3 py-2.5`}
+            >
+              <div className="flex items-center gap-1.5 mb-1">
+                <span
+                  className="w-2 h-2 rounded-full shrink-0"
+                  style={{ backgroundColor: style.color }}
+                />
+                <span className="text-[10px] uppercase tracking-wider text-cream-dim/60">
+                  {style.label}
+                </span>
+              </div>
+              <div className="text-base font-bold text-cream">
+                {avg != null ? fmtAUD(avg) : "—"}
+              </div>
+              <div className="text-[10px] text-cream-dim/40 mt-0.5">
+                avg · {r.card_count} card{r.card_count !== 1 ? "s" : ""}
+              </div>
+              <div className="text-[10px] text-cream-dim/50 mt-1">
+                {pct.toFixed(0)}% of set value
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Bar chart: average price by rarity */}
+      <div className="rounded-lg border border-subtle bg-surface overflow-hidden">
+        <div className="px-3 pt-3 pb-1 text-[10px] text-cream-dim/40 uppercase tracking-wider">
+          Average price by rarity (AUD)
+        </div>
+        <ResponsiveContainer width="100%" height={160}>
+          <BarChart
+            data={chartData}
+            margin={{ top: 8, right: 16, bottom: 4, left: -4 }}
+          >
+            <XAxis
+              dataKey="rarity"
+              tick={{ fill: "var(--color-cream-dim, #a09880)", fontSize: 10, opacity: 0.7 }}
+              tickLine={false}
+              axisLine={false}
+            />
+            <YAxis
+              tickFormatter={(v) => `$${v.toFixed(0)}`}
+              tick={{ fill: "var(--color-cream-dim, #a09880)", fontSize: 9, opacity: 0.6 }}
+              tickLine={false}
+              axisLine={false}
+              width={34}
+            />
+            <Tooltip
+              contentStyle={tooltipStyle}
+              formatter={((value: number) => [fmtAUD(value), "Avg price"]) as never}
+            />
+            <Bar dataKey="avg" radius={[3, 3, 0, 0]}>
+              {chartData.map((entry) => (
+                <Cell
+                  key={entry.key}
+                  fill={RARITY_STYLE[entry.key]?.color ?? "#888"}
+                  fillOpacity={0.8}
+                />
+              ))}
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+
+      {totalValue > 0 && (
+        <p className="text-[11px] text-cream-dim/40 leading-relaxed">
+          Total in-stock value across all rarities: <strong className="text-cream-dim/70">{fmtAUD(totalValue)}</strong>.
+          {breakdown.find((r) => r.rarity === "mythic") &&
+          breakdown.find((r) => r.rarity === "rare") ? (
+            <>
+              {" "}
+              Mythics average{" "}
+              {fmtAUD(
+                parseFloat(
+                  breakdown.find((r) => r.rarity === "mythic")?.avg_price ?? "0"
+                )
+              )}{" "}
+              vs{" "}
+              {fmtAUD(
+                parseFloat(
+                  breakdown.find((r) => r.rarity === "rare")?.avg_price ?? "0"
+                )
+              )}{" "}
+              for rares.
+            </>
+          ) : null}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/sets/[setCode]/ReprintImpact.tsx
+++ b/apps/web/src/app/sets/[setCode]/ReprintImpact.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import type { SetReprintCard } from "@/lib/db";
+import { fmtAUD, cardHref } from "@/lib/utils";
+import { CardThumb } from "@/app/CardThumb";
+
+const RARITY_BADGE: Record<string, { label: string; class: string }> = {
+  mythic:   { label: "M", class: "bg-orange-900/30 text-orange-400 border-orange-900/40" },
+  rare:     { label: "R", class: "bg-yellow-900/30 text-yellow-400 border-yellow-900/40" },
+  uncommon: { label: "U", class: "bg-blue-900/30 text-blue-300 border-blue-900/40" },
+  common:   { label: "C", class: "bg-subtle text-cream-dim border-subtle" },
+};
+
+export function ReprintImpact({ cards, setCode, setName }: { cards: SetReprintCard[]; setCode: string; setName: string }) {
+  if (cards.length === 0) return null;
+
+  return (
+    <div className="rounded-xl border border-subtle bg-surface overflow-hidden">
+      {/* Header */}
+      <div className="grid grid-cols-[auto_1fr_auto_auto_auto] border-b border-subtle bg-cream-muted/30">
+        <div className="px-3 py-2" />
+        <div className="px-2 py-2 text-[10px] uppercase tracking-wider text-cream-dim/40">Card</div>
+        <div className="px-3 py-2 text-[10px] uppercase tracking-wider text-cream-dim/40 text-right">
+          This set
+        </div>
+        <div className="px-3 py-2 text-[10px] uppercase tracking-wider text-cream-dim/40 text-right hidden sm:block">
+          Cheapest other
+        </div>
+        <div className="px-3 py-2 text-[10px] uppercase tracking-wider text-cream-dim/40 text-right">
+          Diff
+        </div>
+      </div>
+
+      <div className="divide-y divide-subtle/30">
+        {cards.map((card) => {
+          const newPrice = card.new_printing_price ? parseFloat(card.new_printing_price) : null;
+          const otherPrice = card.other_printing_price ? parseFloat(card.other_printing_price) : null;
+          const pct = card.pct_diff ? parseFloat(card.pct_diff) : null;
+          const badge = RARITY_BADGE[card.rarity];
+
+          // Negative pct = this set is cheaper (good for buyers), positive = other set is cheaper
+          const diffClass =
+            pct == null ? "text-cream-dim/30"
+            : pct < -5 ? "text-green-400"   // new printing is cheaper
+            : pct > 5  ? "text-red-400"     // new printing is more expensive
+            : "text-cream-dim/50";
+
+          return (
+            <a
+              key={card.card_id}
+              href={cardHref(card.slug, card.card_id, { code: setCode, name: setName })}
+              className="grid grid-cols-[auto_1fr_auto_auto_auto] items-center hover:bg-muted transition-colors group"
+            >
+              <div className="px-2 py-1.5">
+                <CardThumb
+                  imageUri={card.image_uri}
+                  alt={card.name}
+                  className="w-6 h-8 opacity-80 group-hover:opacity-100 transition-opacity"
+                />
+              </div>
+              <div className="px-2 py-1.5 min-w-0 flex items-center gap-1.5">
+                {badge && (
+                  <span className={`text-[8px] font-bold border rounded px-1 py-0.5 shrink-0 ${badge.class}`}>
+                    {badge.label}
+                  </span>
+                )}
+                <span className="text-xs text-cream truncate group-hover:text-accent transition-colors">
+                  {card.name}
+                </span>
+              </div>
+              <div className="px-3 py-1.5 text-right">
+                <span className="text-xs font-semibold text-price">
+                  {newPrice != null ? fmtAUD(newPrice) : "—"}
+                </span>
+              </div>
+              <div className="hidden sm:block px-3 py-1.5 text-right">
+                <span className="text-[10px] text-cream-dim/50">
+                  {otherPrice != null ? fmtAUD(otherPrice) : "—"}
+                </span>
+              </div>
+              <div className="px-3 py-1.5 text-right w-16">
+                <span className={`text-xs font-medium ${diffClass}`}>
+                  {pct != null ? `${pct > 0 ? "+" : ""}${pct.toFixed(0)}%` : "—"}
+                </span>
+              </div>
+            </a>
+          );
+        })}
+      </div>
+
+      <div className="px-3 py-2 border-t border-subtle/50 text-[10px] text-cream-dim/30">
+        Diff = (this set price − cheapest other printing) ÷ cheapest other printing ·{" "}
+        <span className="text-green-400/60">green = new printing is cheaper</span> ·{" "}
+        <span className="text-red-400/60">red = older printing is cheaper</span>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/sets/[setCode]/SetCardExplorer.tsx
+++ b/apps/web/src/app/sets/[setCode]/SetCardExplorer.tsx
@@ -3,6 +3,7 @@
 import { useState, useMemo } from "react";
 import type { SetCardPerf } from "@/lib/db";
 import { fmtAUD, cardHref } from "@/lib/utils";
+import { CardThumb } from "@/app/CardThumb";
 
 type SortKey = "name" | "current_price" | "pct_change" | "rarity";
 type SortDir = "asc" | "desc";
@@ -55,13 +56,18 @@ function SortHeader({
 export function SetCardExplorer({
   cardPerf,
   setCode,
+  setName,
+  rarityFilter,
+  onRarityFilterChange,
 }: {
   cardPerf: SetCardPerf[];
   setCode: string;
+  setName: string;
+  rarityFilter: string;
+  onRarityFilterChange: (r: string) => void;
 }) {
   const [sortKey, setSortKey] = useState<SortKey>("pct_change");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
-  const [rarityFilter, setRarityFilter] = useState<string>("all");
   const [page, setPage] = useState(0);
 
   function handleSort(key: SortKey) {
@@ -116,7 +122,7 @@ export function SetCardExplorer({
   const pageSlice = sorted.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE);
 
   return (
-    <div className="space-y-3">
+    <div id="all-cards" className="space-y-3">
       {/* Controls */}
       <div className="flex flex-wrap items-center gap-2">
         <span className="text-[10px] text-cream-dim/40 uppercase tracking-wider">
@@ -127,7 +133,7 @@ export function SetCardExplorer({
           return (
             <button
               key={r}
-              onClick={() => { setRarityFilter(r); setPage(0); }}
+              onClick={() => { onRarityFilterChange(r); setPage(0); }}
               className={`rounded px-2 py-0.5 text-[10px] font-medium border transition-colors ${
                 rarityFilter === r
                   ? "bg-accent-muted text-accent-light border-accent-border"
@@ -180,24 +186,16 @@ export function SetCardExplorer({
               return (
                 <a
                   key={card.card_id}
-                  href={cardHref(card.slug, card.card_id)}
+                  href={cardHref(card.slug, card.card_id, { code: setCode, name: setName })}
                   className="grid grid-cols-[auto_1fr_auto_auto] sm:grid-cols-[auto_1fr_auto_auto_auto] items-center gap-0 hover:bg-muted transition-colors group"
                 >
                   {/* Thumbnail */}
                   <div className="px-2 py-1.5">
-                    {card.image_uri ? (
-                      // eslint-disable-next-line @next/next/no-img-element
-                      <img
-                        src={card.image_uri}
-                        alt={card.name}
-                        width={24}
-                        height={33}
-                        className="rounded shrink-0 opacity-80 group-hover:opacity-100 transition-opacity"
-                        loading="lazy"
-                      />
-                    ) : (
-                      <div className="w-6 h-8 rounded bg-subtle" />
-                    )}
+                    <CardThumb
+                      imageUri={card.image_uri}
+                      alt={card.name}
+                      className="w-6 h-8 opacity-80 group-hover:opacity-100 transition-opacity"
+                    />
                   </div>
 
                   {/* Name + rarity */}

--- a/apps/web/src/app/sets/[setCode]/SetCardExplorer.tsx
+++ b/apps/web/src/app/sets/[setCode]/SetCardExplorer.tsx
@@ -1,0 +1,283 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import type { SetCardPerf } from "@/lib/db";
+import { fmtAUD, cardHref } from "@/lib/utils";
+
+type SortKey = "name" | "current_price" | "pct_change" | "rarity";
+type SortDir = "asc" | "desc";
+
+const RARITY_ORDER: Record<string, number> = {
+  mythic: 1,
+  rare: 2,
+  uncommon: 3,
+  common: 4,
+};
+
+const RARITY_BADGE: Record<string, { label: string; class: string }> = {
+  mythic: { label: "M", class: "bg-orange-900/30 text-orange-400 border-orange-900/40" },
+  rare: { label: "R", class: "bg-yellow-900/30 text-yellow-400 border-yellow-900/40" },
+  uncommon: { label: "U", class: "bg-blue-900/30 text-blue-300 border-blue-900/40" },
+  common: { label: "C", class: "bg-subtle text-cream-dim border-subtle" },
+};
+
+const PAGE_SIZE = 25;
+
+function SortHeader({
+  label,
+  sortKey,
+  current,
+  dir,
+  onSort,
+  className,
+}: {
+  label: string;
+  sortKey: SortKey;
+  current: SortKey;
+  dir: SortDir;
+  onSort: (k: SortKey) => void;
+  className?: string;
+}) {
+  const active = current === sortKey;
+  return (
+    <button
+      onClick={() => onSort(sortKey)}
+      className={`text-left text-[10px] uppercase tracking-wider text-cream-dim/40 hover:text-cream-dim transition-colors flex items-center gap-0.5 ${className}`}
+    >
+      {label}
+      {active ? (
+        <span className="text-accent ml-0.5">{dir === "asc" ? "↑" : "↓"}</span>
+      ) : null}
+    </button>
+  );
+}
+
+export function SetCardExplorer({
+  cardPerf,
+  setCode,
+}: {
+  cardPerf: SetCardPerf[];
+  setCode: string;
+}) {
+  const [sortKey, setSortKey] = useState<SortKey>("pct_change");
+  const [sortDir, setSortDir] = useState<SortDir>("desc");
+  const [rarityFilter, setRarityFilter] = useState<string>("all");
+  const [page, setPage] = useState(0);
+
+  function handleSort(key: SortKey) {
+    if (key === sortKey) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    } else {
+      setSortKey(key);
+      setSortDir(key === "name" ? "asc" : "desc");
+    }
+    setPage(0);
+  }
+
+  const rarities = useMemo(
+    () => ["all", ...Array.from(new Set(cardPerf.map((c) => c.rarity))).sort((a, b) => (RARITY_ORDER[a] ?? 9) - (RARITY_ORDER[b] ?? 9))],
+    [cardPerf]
+  );
+
+  const filtered = useMemo(
+    () =>
+      rarityFilter === "all"
+        ? cardPerf
+        : cardPerf.filter((c) => c.rarity === rarityFilter),
+    [cardPerf, rarityFilter]
+  );
+
+  const sorted = useMemo(() => {
+    return [...filtered].sort((a, b) => {
+      let cmp = 0;
+      switch (sortKey) {
+        case "name":
+          cmp = a.name.localeCompare(b.name);
+          break;
+        case "current_price":
+          cmp =
+            (a.current_price != null ? parseFloat(a.current_price) : -1) -
+            (b.current_price != null ? parseFloat(b.current_price) : -1);
+          break;
+        case "pct_change":
+          cmp =
+            (a.pct_change != null ? parseFloat(a.pct_change) : -9999) -
+            (b.pct_change != null ? parseFloat(b.pct_change) : -9999);
+          break;
+        case "rarity":
+          cmp = (RARITY_ORDER[a.rarity] ?? 9) - (RARITY_ORDER[b.rarity] ?? 9);
+          break;
+      }
+      return sortDir === "asc" ? cmp : -cmp;
+    });
+  }, [filtered, sortKey, sortDir]);
+
+  const totalPages = Math.ceil(sorted.length / PAGE_SIZE);
+  const pageSlice = sorted.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE);
+
+  return (
+    <div className="space-y-3">
+      {/* Controls */}
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-[10px] text-cream-dim/40 uppercase tracking-wider">
+          Rarity
+        </span>
+        {rarities.map((r) => {
+          const badge = RARITY_BADGE[r];
+          return (
+            <button
+              key={r}
+              onClick={() => { setRarityFilter(r); setPage(0); }}
+              className={`rounded px-2 py-0.5 text-[10px] font-medium border transition-colors ${
+                rarityFilter === r
+                  ? "bg-accent-muted text-accent-light border-accent-border"
+                  : "bg-muted text-cream-dim/50 border-subtle hover:text-cream-dim"
+              }`}
+            >
+              {badge ? badge.label : "All"}
+            </button>
+          );
+        })}
+        <span className="ml-auto text-[10px] text-cream-dim/30">
+          {filtered.length} card{filtered.length !== 1 ? "s" : ""}
+        </span>
+      </div>
+
+      {/* Table */}
+      <div className="rounded-xl border border-subtle bg-surface overflow-hidden">
+        {/* Header */}
+        <div className="grid grid-cols-[auto_1fr_auto_auto] sm:grid-cols-[auto_1fr_auto_auto_auto] gap-0 border-b border-subtle bg-cream-muted/30">
+          <div className="px-3 py-2" />
+          <div className="px-2 py-2">
+            <SortHeader label="Card" sortKey="name" current={sortKey} dir={sortDir} onSort={handleSort} />
+          </div>
+          <div className="px-3 py-2">
+            <SortHeader label="Price" sortKey="current_price" current={sortKey} dir={sortDir} onSort={handleSort} className="justify-end" />
+          </div>
+          <div className="hidden sm:block px-3 py-2">
+            <SortHeader label="Was" sortKey="current_price" current={sortKey} dir={sortDir} onSort={handleSort} className="justify-end" />
+          </div>
+          <div className="px-3 py-2">
+            <SortHeader label="Chg" sortKey="pct_change" current={sortKey} dir={sortDir} onSort={handleSort} className="justify-end" />
+          </div>
+        </div>
+
+        {/* Rows */}
+        {pageSlice.length === 0 ? (
+          <div className="px-4 py-8 text-center text-sm text-cream-dim/40">
+            No cards match the selected filter.
+          </div>
+        ) : (
+          <div className="divide-y divide-subtle/30">
+            {pageSlice.map((card) => {
+              const pct = card.pct_change != null ? parseFloat(card.pct_change) : null;
+              const current =
+                card.current_price != null ? parseFloat(card.current_price) : null;
+              const first =
+                card.first_price != null ? parseFloat(card.first_price) : null;
+              const badge = RARITY_BADGE[card.rarity];
+
+              return (
+                <a
+                  key={card.card_id}
+                  href={cardHref(card.slug, card.card_id)}
+                  className="grid grid-cols-[auto_1fr_auto_auto] sm:grid-cols-[auto_1fr_auto_auto_auto] items-center gap-0 hover:bg-muted transition-colors group"
+                >
+                  {/* Thumbnail */}
+                  <div className="px-2 py-1.5">
+                    {card.image_uri ? (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img
+                        src={card.image_uri}
+                        alt={card.name}
+                        width={24}
+                        height={33}
+                        className="rounded shrink-0 opacity-80 group-hover:opacity-100 transition-opacity"
+                        loading="lazy"
+                      />
+                    ) : (
+                      <div className="w-6 h-8 rounded bg-subtle" />
+                    )}
+                  </div>
+
+                  {/* Name + rarity */}
+                  <div className="px-2 py-1.5 min-w-0 flex items-center gap-1.5">
+                    {badge && (
+                      <span
+                        className={`text-[8px] font-bold border rounded px-1 py-0.5 shrink-0 ${badge.class}`}
+                      >
+                        {badge.label}
+                      </span>
+                    )}
+                    <span className="text-xs text-cream truncate group-hover:text-accent transition-colors">
+                      {card.name}
+                    </span>
+                  </div>
+
+                  {/* Current price */}
+                  <div className="px-3 py-1.5 text-right">
+                    <span className="text-xs font-semibold text-price">
+                      {current != null ? fmtAUD(current) : "—"}
+                    </span>
+                  </div>
+
+                  {/* First price (desktop) */}
+                  <div className="hidden sm:block px-3 py-1.5 text-right">
+                    <span className="text-[10px] text-cream-dim/40">
+                      {first != null ? fmtAUD(first) : "—"}
+                    </span>
+                  </div>
+
+                  {/* % change */}
+                  <div className="px-3 py-1.5 text-right w-16">
+                    {pct != null ? (
+                      <span
+                        className={`text-xs font-medium ${
+                          pct > 0 ? "text-red-400" : pct < 0 ? "text-green-400" : "text-cream-dim/40"
+                        }`}
+                      >
+                        {pct > 0 ? "+" : ""}
+                        {pct.toFixed(0)}%
+                      </span>
+                    ) : (
+                      <span className="text-[10px] text-cream-dim/20">—</span>
+                    )}
+                  </div>
+                </a>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between text-xs text-cream-dim/50">
+          <button
+            onClick={() => setPage((p) => Math.max(0, p - 1))}
+            disabled={page === 0}
+            className="px-3 py-1 rounded border border-subtle bg-muted hover:text-cream disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+          >
+            ← Prev
+          </button>
+          <span>
+            Page {page + 1} of {totalPages}
+          </span>
+          <button
+            onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+            disabled={page === totalPages - 1}
+            className="px-3 py-1 rounded border border-subtle bg-muted hover:text-cream disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+          >
+            Next →
+          </button>
+        </div>
+      )}
+
+      <div className="text-[10px] text-cream-dim/30 text-center">
+        % change = (current price − first recorded price) ÷ first recorded price ·{" "}
+        <span className="text-green-400/60">green = cheaper now</span> ·{" "}
+        <span className="text-red-400/60">red = more expensive now</span>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/sets/[setCode]/SetDataStory.tsx
+++ b/apps/web/src/app/sets/[setCode]/SetDataStory.tsx
@@ -1,25 +1,43 @@
 "use client";
 
+import { useState, useCallback } from "react";
+import { useRouter, usePathname } from "next/navigation";
 import type {
   SetMetadata,
   SetPriceTimelinePoint,
   SetCardPerf,
   SetRarityBreakdown,
-  SetStoreComparison,
+  SetReprintCard,
+  ChildSet,
 } from "@/lib/db";
 import { SetHero } from "./SetHero";
 import { CrashCurveChart } from "./CrashCurveChart";
 import { WinnersLosersBoard } from "./WinnersLosersBoard";
-import { RarityBreakdown } from "./RarityBreakdown";
-import { StoreComparison } from "./StoreComparison";
 import { SetCardExplorer } from "./SetCardExplorer";
+import { ReprintImpact } from "./ReprintImpact";
+
+const SET_TYPE_LABEL: Record<string, string> = {
+  commander: "Commander",
+  promo: "Promo",
+  memorabilia: "Secret Lair",
+  token: "Tokens",
+  box: "Box Set",
+  draft_innovation: "Draft Innovation",
+  masters: "Masters",
+  expansion: "Expansion",
+  core: "Core",
+  starter: "Starter",
+  funny: "Acorn",
+};
 
 interface SetDataStoryProps {
   meta: SetMetadata;
   timeline: SetPriceTimelinePoint[];
   cardPerf: SetCardPerf[];
   rarityBreakdown: SetRarityBreakdown[];
-  storeComparison: SetStoreComparison[];
+  reprintCards: SetReprintCard[];
+  childSets: ChildSet[];
+  activeSubsets: string[];
 }
 
 export function SetDataStory({
@@ -27,24 +45,103 @@ export function SetDataStory({
   timeline,
   cardPerf,
   rarityBreakdown,
-  storeComparison,
+  reprintCards,
+  childSets,
+  activeSubsets,
 }: SetDataStoryProps) {
   const hasHistory = timeline.length >= 2;
   const hasPerf = cardPerf.length > 0;
 
+  // Rarity filter — lifted here so hero Mythics button can control it
+  const [rarityFilter, setRarityFilter] = useState<string>("all");
+
+  const router = useRouter();
+  const pathname = usePathname();
+
+  // Subset toggle — opt-out from the default (all non-token children included).
+  // When resulting set equals the full default, navigate to clean URL.
+  function toggleSubset(code: string) {
+    const next = new Set(activeSubsets);
+    if (next.has(code)) {
+      next.delete(code);
+    } else {
+      next.add(code);
+    }
+    // If all non-token children are still selected → clean URL (default state)
+    const isDefault = childSets.every((cs) => next.has(cs.set_code));
+    if (isDefault) {
+      router.push(pathname);
+    } else {
+      // ?subsets= with empty string means "no subsets" (just main set)
+      router.push(`${pathname}?subsets=${[...next].join(",")}`);
+    }
+  }
+
+  function scrollToAllCards() {
+    document.getElementById("all-cards")?.scrollIntoView({ behavior: "smooth" });
+  }
+
+  const handleCardsClick = useCallback(() => {
+    scrollToAllCards();
+  }, []);
+
+  const handleMythicsClick = useCallback(() => {
+    setRarityFilter("mythic");
+    // Small delay so the filter state has time to apply before scrolling
+    setTimeout(scrollToAllCards, 50);
+  }, []);
+
+  const handleReprintsClick = useCallback(() => {
+    document.getElementById("reprint-impact")?.scrollIntoView({ behavior: "smooth" });
+  }, []);
+
   return (
     <div className="max-w-4xl mx-auto space-y-10">
       {/* ── 1. Hero ──────────────────────────────────────────────────────── */}
-      <SetHero meta={meta} timeline={timeline} />
+      <SetHero
+        meta={meta}
+        timeline={timeline}
+        reprintCount={reprintCards.length}
+        onCardsClick={handleCardsClick}
+        onMythicsClick={handleMythicsClick}
+        onReprintsClick={reprintCards.length > 0 ? handleReprintsClick : undefined}
+      />
 
-      {/* ── 2. The Crash Curve ───────────────────────────────────────────── */}
+      {/* ── Subset filter ────────────────────────────────────────────────── */}
+      {childSets.length > 0 && (
+        <div className="flex flex-wrap items-center gap-2 -mt-6">
+          <span className="text-[10px] text-cream-dim/40 uppercase tracking-wider">
+            Includes
+          </span>
+          {childSets.map((cs) => {
+            const included = activeSubsets.includes(cs.set_code);
+            const label = cs.set_type ? (SET_TYPE_LABEL[cs.set_type] ?? cs.set_name) : cs.set_name;
+            return (
+              <button
+                key={cs.set_code}
+                onClick={() => toggleSubset(cs.set_code)}
+                title={`${included ? "Exclude" : "Include"} ${cs.set_name}`}
+                className={`rounded-full px-2.5 py-0.5 text-[10px] font-medium border transition-colors ${
+                  included
+                    ? "bg-accent-muted text-accent-light border-accent-border"
+                    : "bg-muted text-cream-dim/30 border-subtle line-through hover:text-cream-dim/50"
+                }`}
+              >
+                {label}
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      {/* ── 2. The Price Story (with rarity overlay) ─────────────────────── */}
       {hasHistory && (
         <section>
           <SectionHeader
-            title="The Price Story"
+            title="AU Market Breakdown"
             subtitle="Total market value of all cards in the set over time"
           />
-          <CrashCurveChart timeline={timeline} />
+          <CrashCurveChart timeline={timeline} rarityBreakdown={rarityBreakdown} />
         </section>
       )}
 
@@ -55,29 +152,18 @@ export function SetDataStory({
             title="Winners & Losers"
             subtitle="Price change from first recorded price to today (non-foil)"
           />
-          <WinnersLosersBoard cardPerf={cardPerf} setCode={meta.set_code} />
+          <WinnersLosersBoard cardPerf={cardPerf} setCode={meta.set_code} setName={meta.set_name} />
         </section>
       )}
 
-      {/* ── 4. Rarity Breakdown ──────────────────────────────────────────── */}
-      {rarityBreakdown.length > 0 && (
-        <section>
+      {/* ── 4. Reprint Impact ────────────────────────────────────────────── */}
+      {reprintCards.length > 0 && (
+        <section id="reprint-impact">
           <SectionHeader
-            title="Value by Rarity"
-            subtitle="How set value is distributed across rarities"
+            title="Reprint Impact"
+            subtitle="How this set's reprints compare to other printings in stock"
           />
-          <RarityBreakdown breakdown={rarityBreakdown} />
-        </section>
-      )}
-
-      {/* ── 5. Store Comparison ──────────────────────────────────────────── */}
-      {storeComparison.length > 0 && (
-        <section>
-          <SectionHeader
-            title="Store Coverage"
-            subtitle={`Which AU stores are stocking ${meta.set_name}`}
-          />
-          <StoreComparison stores={storeComparison} totalCards={meta.unique_cards} />
+          <ReprintImpact cards={reprintCards} setCode={meta.set_code} setName={meta.set_name} />
         </section>
       )}
 
@@ -88,7 +174,13 @@ export function SetDataStory({
             title="All Cards"
             subtitle="Browse every card in the set with current prices"
           />
-          <SetCardExplorer cardPerf={cardPerf} setCode={meta.set_code} />
+          <SetCardExplorer
+            cardPerf={cardPerf}
+            setCode={meta.set_code}
+            setName={meta.set_name}
+            rarityFilter={rarityFilter}
+            onRarityFilterChange={setRarityFilter}
+          />
         </section>
       )}
 
@@ -106,13 +198,7 @@ export function SetDataStory({
   );
 }
 
-function SectionHeader({
-  title,
-  subtitle,
-}: {
-  title: string;
-  subtitle: string;
-}) {
+function SectionHeader({ title, subtitle }: { title: string; subtitle: string }) {
   return (
     <div className="mb-4">
       <h2 className="text-lg font-semibold text-cream">{title}</h2>

--- a/apps/web/src/app/sets/[setCode]/SetDataStory.tsx
+++ b/apps/web/src/app/sets/[setCode]/SetDataStory.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import type {
+  SetMetadata,
+  SetPriceTimelinePoint,
+  SetCardPerf,
+  SetRarityBreakdown,
+  SetStoreComparison,
+} from "@/lib/db";
+import { SetHero } from "./SetHero";
+import { CrashCurveChart } from "./CrashCurveChart";
+import { WinnersLosersBoard } from "./WinnersLosersBoard";
+import { RarityBreakdown } from "./RarityBreakdown";
+import { StoreComparison } from "./StoreComparison";
+import { SetCardExplorer } from "./SetCardExplorer";
+
+interface SetDataStoryProps {
+  meta: SetMetadata;
+  timeline: SetPriceTimelinePoint[];
+  cardPerf: SetCardPerf[];
+  rarityBreakdown: SetRarityBreakdown[];
+  storeComparison: SetStoreComparison[];
+}
+
+export function SetDataStory({
+  meta,
+  timeline,
+  cardPerf,
+  rarityBreakdown,
+  storeComparison,
+}: SetDataStoryProps) {
+  const hasHistory = timeline.length >= 2;
+  const hasPerf = cardPerf.length > 0;
+
+  return (
+    <div className="max-w-4xl mx-auto space-y-10">
+      {/* ── 1. Hero ──────────────────────────────────────────────────────── */}
+      <SetHero meta={meta} timeline={timeline} />
+
+      {/* ── 2. The Crash Curve ───────────────────────────────────────────── */}
+      {hasHistory && (
+        <section>
+          <SectionHeader
+            title="The Price Story"
+            subtitle="Total market value of all cards in the set over time"
+          />
+          <CrashCurveChart timeline={timeline} />
+        </section>
+      )}
+
+      {/* ── 3. Winners & Losers ──────────────────────────────────────────── */}
+      {hasPerf && (
+        <section>
+          <SectionHeader
+            title="Winners & Losers"
+            subtitle="Price change from first recorded price to today (non-foil)"
+          />
+          <WinnersLosersBoard cardPerf={cardPerf} setCode={meta.set_code} />
+        </section>
+      )}
+
+      {/* ── 4. Rarity Breakdown ──────────────────────────────────────────── */}
+      {rarityBreakdown.length > 0 && (
+        <section>
+          <SectionHeader
+            title="Value by Rarity"
+            subtitle="How set value is distributed across rarities"
+          />
+          <RarityBreakdown breakdown={rarityBreakdown} />
+        </section>
+      )}
+
+      {/* ── 5. Store Comparison ──────────────────────────────────────────── */}
+      {storeComparison.length > 0 && (
+        <section>
+          <SectionHeader
+            title="Store Coverage"
+            subtitle={`Which AU stores are stocking ${meta.set_name}`}
+          />
+          <StoreComparison stores={storeComparison} totalCards={meta.unique_cards} />
+        </section>
+      )}
+
+      {/* ── 6. Full Card Explorer ────────────────────────────────────────── */}
+      {hasPerf && (
+        <section>
+          <SectionHeader
+            title="All Cards"
+            subtitle="Browse every card in the set with current prices"
+          />
+          <SetCardExplorer cardPerf={cardPerf} setCode={meta.set_code} />
+        </section>
+      )}
+
+      {/* Empty state */}
+      {!hasHistory && !hasPerf && (
+        <div className="rounded-xl border border-subtle bg-surface p-10 text-center">
+          <div className="text-3xl mb-3">📊</div>
+          <div className="font-medium text-cream mb-1">Price data building…</div>
+          <div className="text-sm text-cream-dim/50">
+            Price history for {meta.set_name} will appear after AU stores are scraped.
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SectionHeader({
+  title,
+  subtitle,
+}: {
+  title: string;
+  subtitle: string;
+}) {
+  return (
+    <div className="mb-4">
+      <h2 className="text-lg font-semibold text-cream">{title}</h2>
+      <p className="text-xs text-cream-dim/50 mt-0.5">{subtitle}</p>
+    </div>
+  );
+}

--- a/apps/web/src/app/sets/[setCode]/SetHero.tsx
+++ b/apps/web/src/app/sets/[setCode]/SetHero.tsx
@@ -1,5 +1,6 @@
 import type { SetMetadata, SetPriceTimelinePoint } from "@/lib/db";
 import { fmtAUD } from "@/lib/utils";
+import { Breadcrumb } from "@/app/Breadcrumb";
 
 function formatDate(dateStr: string) {
   return new Date(dateStr).toLocaleDateString("en-AU", {
@@ -21,9 +22,17 @@ function computeOverallChange(timeline: SetPriceTimelinePoint[]): number | null 
 export function SetHero({
   meta,
   timeline,
+  reprintCount,
+  onCardsClick,
+  onMythicsClick,
+  onReprintsClick,
 }: {
   meta: SetMetadata;
   timeline: SetPriceTimelinePoint[];
+  reprintCount: number;
+  onCardsClick: () => void;
+  onMythicsClick: () => void;
+  onReprintsClick?: () => void;
 }) {
   const currentValue =
     timeline.length > 0
@@ -39,14 +48,10 @@ export function SetHero({
 
   return (
     <div className="mb-8">
-      {/* Breadcrumb */}
-      <div className="text-[11px] text-cream-dim/40 mb-4">
-        <a href="/sets" className="hover:text-accent transition-colors">
-          Sets
-        </a>
-        <span className="mx-1.5">›</span>
-        <span>{meta.set_name}</span>
-      </div>
+      <Breadcrumb items={[
+        { label: "Sets", href: "/sets" },
+        { label: meta.set_name },
+      ]} />
 
       <div className="rounded-xl border border-subtle bg-surface p-5 sm:p-6">
         <div className="flex flex-col sm:flex-row sm:items-start gap-4">
@@ -102,32 +107,51 @@ export function SetHero({
                 )}
               </div>
 
-              {/* Cards */}
-              <div className="rounded-lg bg-muted border border-subtle px-3 py-2.5">
-                <div className="text-[10px] text-cream-dim/40 uppercase tracking-wider mb-0.5">
+              {/* Cards — clickable, scrolls to All Cards */}
+              <button
+                onClick={onCardsClick}
+                className="rounded-lg bg-muted border border-subtle px-3 py-2.5 text-left hover:border-accent/40 hover:bg-muted/80 transition-colors group"
+              >
+                <div className="text-[10px] text-cream-dim/40 uppercase tracking-wider mb-0.5 group-hover:text-accent/60 transition-colors">
                   Cards
                 </div>
                 <div className="text-lg font-bold text-cream">{meta.unique_cards}</div>
-                <div className="text-[10px] text-cream-dim/40">unique</div>
-              </div>
+                <div className="text-[10px] text-cream-dim/40">unique ↓</div>
+              </button>
 
-              {/* Mythics */}
-              <div className="rounded-lg bg-muted border border-subtle px-3 py-2.5">
-                <div className="text-[10px] text-cream-dim/40 uppercase tracking-wider mb-0.5">
+              {/* Mythics — clickable, scrolls to All Cards + applies mythic filter */}
+              <button
+                onClick={onMythicsClick}
+                className="rounded-lg bg-muted border border-subtle px-3 py-2.5 text-left hover:border-orange-500/40 hover:bg-muted/80 transition-colors group"
+              >
+                <div className="text-[10px] text-cream-dim/40 uppercase tracking-wider mb-0.5 group-hover:text-orange-400/60 transition-colors">
                   Mythics
                 </div>
                 <div className="text-lg font-bold text-cream">{meta.mythic_count}</div>
-                <div className="text-[10px] text-cream-dim/40">{meta.rare_count} rares</div>
-              </div>
+                <div className="text-[10px] text-cream-dim/40">{meta.rare_count} rares ↓</div>
+              </button>
 
-              {/* Data range */}
-              <div className="rounded-lg bg-muted border border-subtle px-3 py-2.5">
-                <div className="text-[10px] text-cream-dim/40 uppercase tracking-wider mb-0.5">
-                  Data points
+              {/* Reprints */}
+              {onReprintsClick ? (
+                <button
+                  onClick={onReprintsClick}
+                  className="rounded-lg bg-muted border border-subtle px-3 py-2.5 text-left hover:border-accent/40 hover:bg-muted/80 transition-colors group"
+                >
+                  <div className="text-[10px] text-cream-dim/40 uppercase tracking-wider mb-0.5 group-hover:text-accent/60 transition-colors">
+                    Reprints
+                  </div>
+                  <div className="text-lg font-bold text-cream">{reprintCount}</div>
+                  <div className="text-[10px] text-cream-dim/40">in this set ↓</div>
+                </button>
+              ) : (
+                <div className="rounded-lg bg-muted border border-subtle px-3 py-2.5">
+                  <div className="text-[10px] text-cream-dim/40 uppercase tracking-wider mb-0.5">
+                    Reprints
+                  </div>
+                  <div className="text-lg font-bold text-cream">{reprintCount}</div>
+                  <div className="text-[10px] text-cream-dim/40">in this set</div>
                 </div>
-                <div className="text-lg font-bold text-cream">{timeline.length}</div>
-                <div className="text-[10px] text-cream-dim/40">daily snapshots</div>
-              </div>
+              )}
             </div>
           </div>
         </div>

--- a/apps/web/src/app/sets/[setCode]/SetHero.tsx
+++ b/apps/web/src/app/sets/[setCode]/SetHero.tsx
@@ -1,0 +1,144 @@
+import type { SetMetadata, SetPriceTimelinePoint } from "@/lib/db";
+import { fmtAUD } from "@/lib/utils";
+
+function formatDate(dateStr: string) {
+  return new Date(dateStr).toLocaleDateString("en-AU", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
+}
+
+/** Percentage change from first to last timeline point. */
+function computeOverallChange(timeline: SetPriceTimelinePoint[]): number | null {
+  if (timeline.length < 2) return null;
+  const first = parseFloat(timeline[0].total_value);
+  const last = parseFloat(timeline[timeline.length - 1].total_value);
+  if (!first) return null;
+  return ((last - first) / first) * 100;
+}
+
+export function SetHero({
+  meta,
+  timeline,
+}: {
+  meta: SetMetadata;
+  timeline: SetPriceTimelinePoint[];
+}) {
+  const currentValue =
+    timeline.length > 0
+      ? parseFloat(timeline[timeline.length - 1].total_value)
+      : null;
+  const overallChange = computeOverallChange(timeline);
+
+  const changePositive = overallChange !== null && overallChange > 0;
+  const changeLabel =
+    overallChange !== null
+      ? `${changePositive ? "+" : ""}${overallChange.toFixed(1)}% since release`
+      : null;
+
+  return (
+    <div className="mb-8">
+      {/* Breadcrumb */}
+      <div className="text-[11px] text-cream-dim/40 mb-4">
+        <a href="/sets" className="hover:text-accent transition-colors">
+          Sets
+        </a>
+        <span className="mx-1.5">›</span>
+        <span>{meta.set_name}</span>
+      </div>
+
+      <div className="rounded-xl border border-subtle bg-surface p-5 sm:p-6">
+        <div className="flex flex-col sm:flex-row sm:items-start gap-4">
+          {/* Set icon */}
+          <div className="flex items-center gap-3 sm:block">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={`https://svgs.scryfall.io/sets/${meta.set_code}.svg`}
+              alt={meta.set_name}
+              width={52}
+              height={52}
+              className="shrink-0 opacity-80"
+              style={{ filter: "invert(55%) sepia(30%) saturate(400%) hue-rotate(155deg)" }}
+              onError={(e) => { (e.target as HTMLImageElement).style.display = "none"; }}
+            />
+            <span className="sm:hidden text-[11px] text-cream-dim/40 uppercase tracking-widest font-mono">
+              {meta.set_code.toUpperCase()}
+            </span>
+          </div>
+
+          <div className="flex-1 min-w-0">
+            {/* Set name + code */}
+            <div className="flex items-baseline gap-2 flex-wrap">
+              <h1 className="text-xl sm:text-2xl font-bold text-cream leading-tight">
+                {meta.set_name}
+              </h1>
+              <span className="hidden sm:inline text-[11px] text-cream-dim/40 uppercase tracking-widest font-mono">
+                {meta.set_code.toUpperCase()}
+              </span>
+            </div>
+            <div className="text-xs text-cream-dim/50 mt-0.5">
+              Released {formatDate(meta.released_at)}
+            </div>
+
+            {/* Stats row */}
+            <div className="mt-4 grid grid-cols-2 sm:grid-cols-4 gap-3">
+              {/* Total value */}
+              <div className="col-span-2 sm:col-span-1 rounded-lg bg-price-muted/60 border border-price/20 px-3 py-2.5">
+                <div className="text-[10px] text-cream-dim/40 uppercase tracking-wider mb-0.5">
+                  Set value
+                </div>
+                <div className="text-xl font-bold text-price">
+                  {currentValue != null ? fmtAUD(currentValue) : "—"}
+                </div>
+                {changeLabel && (
+                  <div
+                    className={`text-[11px] mt-0.5 font-medium ${
+                      changePositive ? "text-red-400" : "text-green-400"
+                    }`}
+                  >
+                    {changeLabel}
+                  </div>
+                )}
+              </div>
+
+              {/* Cards */}
+              <div className="rounded-lg bg-muted border border-subtle px-3 py-2.5">
+                <div className="text-[10px] text-cream-dim/40 uppercase tracking-wider mb-0.5">
+                  Cards
+                </div>
+                <div className="text-lg font-bold text-cream">{meta.unique_cards}</div>
+                <div className="text-[10px] text-cream-dim/40">unique</div>
+              </div>
+
+              {/* Mythics */}
+              <div className="rounded-lg bg-muted border border-subtle px-3 py-2.5">
+                <div className="text-[10px] text-cream-dim/40 uppercase tracking-wider mb-0.5">
+                  Mythics
+                </div>
+                <div className="text-lg font-bold text-cream">{meta.mythic_count}</div>
+                <div className="text-[10px] text-cream-dim/40">{meta.rare_count} rares</div>
+              </div>
+
+              {/* Data range */}
+              <div className="rounded-lg bg-muted border border-subtle px-3 py-2.5">
+                <div className="text-[10px] text-cream-dim/40 uppercase tracking-wider mb-0.5">
+                  Data points
+                </div>
+                <div className="text-lg font-bold text-cream">{timeline.length}</div>
+                <div className="text-[10px] text-cream-dim/40">daily snapshots</div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* No data notice */}
+        {timeline.length === 0 && (
+          <div className="mt-4 rounded-lg bg-muted border border-subtle px-3 py-2 text-[11px] text-cream-dim/50">
+            No price history yet for this set. Price charts will appear after the first scrape run.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/sets/[setCode]/StoreComparison.tsx
+++ b/apps/web/src/app/sets/[setCode]/StoreComparison.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import React, { useMemo } from "react";
 import type { SetStoreComparison } from "@/lib/db";
 import { fmtAUD } from "@/lib/utils";
 
@@ -44,9 +44,8 @@ export function StoreComparison({
           const isBest = i === 0;
 
           return (
-            <>
+            <React.Fragment key={store.store_id}>
               <div
-                key={`name-${store.store_id}`}
                 className="px-4 py-2.5 flex items-center gap-2 border-b border-subtle/50"
               >
                 <div className="min-w-0">
@@ -100,7 +99,7 @@ export function StoreComparison({
                   </span>
                 </span>
               </div>
-            </>
+            </React.Fragment>
           );
         })}
       </div>

--- a/apps/web/src/app/sets/[setCode]/StoreComparison.tsx
+++ b/apps/web/src/app/sets/[setCode]/StoreComparison.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useMemo } from "react";
+import type { SetStoreComparison } from "@/lib/db";
+import { fmtAUD } from "@/lib/utils";
+
+export function StoreComparison({
+  stores,
+  totalCards,
+}: {
+  stores: SetStoreComparison[];
+  totalCards: number;
+}) {
+  const maxCards = useMemo(
+    () => Math.max(...stores.map((s) => s.unique_cards), 1),
+    [stores]
+  );
+
+  return (
+    <div className="rounded-xl border border-subtle bg-surface overflow-hidden">
+      <div className="grid grid-cols-[1fr_auto_auto] sm:grid-cols-[1fr_auto_auto_auto] gap-0">
+        {/* Header */}
+        <div className="px-4 py-2 text-[10px] uppercase tracking-wider text-cream-dim/40 border-b border-subtle bg-cream-muted/30">
+          Store
+        </div>
+        <div className="px-3 py-2 text-[10px] uppercase tracking-wider text-cream-dim/40 border-b border-subtle bg-cream-muted/30 text-right">
+          Avg price
+        </div>
+        <div className="hidden sm:block px-3 py-2 text-[10px] uppercase tracking-wider text-cream-dim/40 border-b border-subtle bg-cream-muted/30 text-right">
+          In stock
+        </div>
+        <div className="px-3 py-2 text-[10px] uppercase tracking-wider text-cream-dim/40 border-b border-subtle bg-cream-muted/30 text-right">
+          Coverage
+        </div>
+
+        {/* Rows */}
+        {stores.map((store, i) => {
+          const avg = store.avg_price ? parseFloat(store.avg_price) : null;
+          const coverage =
+            totalCards > 0
+              ? Math.round((store.unique_cards / totalCards) * 100)
+              : 0;
+          const barWidth = (store.unique_cards / maxCards) * 100;
+          const isBest = i === 0;
+
+          return (
+            <>
+              <div
+                key={`name-${store.store_id}`}
+                className="px-4 py-2.5 flex items-center gap-2 border-b border-subtle/50"
+              >
+                <div className="min-w-0">
+                  <div className="flex items-center gap-1.5">
+                    <span className="text-xs font-medium text-cream truncate">
+                      {store.store_name}
+                    </span>
+                    {isBest && (
+                      <span className="text-[9px] bg-accent-muted text-accent-light border border-accent-border rounded px-1 py-0.5 shrink-0">
+                        lowest avg
+                      </span>
+                    )}
+                  </div>
+                  {/* Coverage bar */}
+                  <div className="mt-1 h-0.5 w-24 rounded-full bg-subtle/50 overflow-hidden">
+                    <div
+                      className="h-full bg-accent/60 rounded-full"
+                      style={{ width: `${barWidth}%` }}
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                key={`avg-${store.store_id}`}
+                className="px-3 py-2.5 text-right border-b border-subtle/50 flex items-center justify-end"
+              >
+                <span
+                  className={`text-xs font-semibold ${
+                    isBest ? "text-price" : "text-cream"
+                  }`}
+                >
+                  {avg != null ? fmtAUD(avg) : "—"}
+                </span>
+              </div>
+              <div
+                key={`stock-${store.store_id}`}
+                className="hidden sm:flex px-3 py-2.5 text-right border-b border-subtle/50 items-center justify-end"
+              >
+                <span className="text-xs text-cream-dim/70">
+                  {store.in_stock_count.toLocaleString()}
+                </span>
+              </div>
+              <div
+                key={`cov-${store.store_id}`}
+                className="px-3 py-2.5 text-right border-b border-subtle/50 flex items-center justify-end"
+              >
+                <span className="text-xs text-cream-dim/70">
+                  {coverage}%
+                  <span className="text-[10px] text-cream-dim/40 ml-1">
+                    ({store.unique_cards}/{totalCards})
+                  </span>
+                </span>
+              </div>
+            </>
+          );
+        })}
+      </div>
+
+      <div className="px-4 py-2 text-[10px] text-cream-dim/40">
+        Average price is across all in-stock non-foil listings for this set.
+        Coverage = unique cards in stock ÷ total cards in set.
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/sets/[setCode]/SymbioticMovers.tsx
+++ b/apps/web/src/app/sets/[setCode]/SymbioticMovers.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import type { SymbioticMover } from "@/lib/db";
+import { fmtAUD, cardHref } from "@/lib/utils";
+import { CardThumb } from "@/app/CardThumb";
+
+export function SymbioticMovers({ movers, setCode }: { movers: SymbioticMover[]; setCode: string }) {
+  if (movers.length === 0) return null;
+
+  return (
+    <div className="rounded-xl border border-subtle bg-surface overflow-hidden">
+      {/* Header */}
+      <div className="grid grid-cols-[auto_1fr_auto_auto_auto] border-b border-subtle bg-cream-muted/30">
+        <div className="px-3 py-2" />
+        <div className="px-2 py-2 text-[10px] uppercase tracking-wider text-cream-dim/40">Card</div>
+        <div className="px-3 py-2 text-[10px] uppercase tracking-wider text-cream-dim/40 text-right hidden sm:block">
+          At release
+        </div>
+        <div className="px-3 py-2 text-[10px] uppercase tracking-wider text-cream-dim/40 text-right">
+          Now
+        </div>
+        <div className="px-3 py-2 text-[10px] uppercase tracking-wider text-cream-dim/40 text-right">
+          Gain
+        </div>
+      </div>
+
+      <div className="divide-y divide-subtle/30">
+        {movers.map((card) => {
+          const first = parseFloat(card.first_price);
+          const current = parseFloat(card.current_price);
+          const pct = parseFloat(card.pct_change);
+
+          return (
+            <a
+              key={card.card_id}
+              href={cardHref(card.slug, card.card_id)}
+              className="grid grid-cols-[auto_1fr_auto_auto_auto] items-center hover:bg-muted transition-colors group"
+            >
+              <div className="px-2 py-1.5">
+                <CardThumb
+                  imageUri={card.image_uri}
+                  alt={card.name}
+                  className="w-6 h-8 opacity-80 group-hover:opacity-100 transition-opacity"
+                />
+              </div>
+              <div className="px-2 py-1.5 min-w-0">
+                <span className="text-xs text-cream truncate block group-hover:text-accent transition-colors">
+                  {card.name}
+                </span>
+              </div>
+              <div className="hidden sm:block px-3 py-1.5 text-right">
+                <span className="text-[10px] text-cream-dim/50">{fmtAUD(first)}</span>
+              </div>
+              <div className="px-3 py-1.5 text-right">
+                <span className="text-xs font-semibold text-price">{fmtAUD(current)}</span>
+              </div>
+              <div className="px-3 py-1.5 text-right w-16">
+                <span className="text-xs font-medium text-red-400">
+                  +{pct.toFixed(0)}%
+                </span>
+              </div>
+            </a>
+          );
+        })}
+      </div>
+
+      <div className="px-3 py-2 border-t border-subtle/50 text-[10px] text-cream-dim/30">
+        Cards not in this set that increased ≥15% since release · may indicate set-driven demand
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/sets/[setCode]/WinnersLosersBoard.tsx
+++ b/apps/web/src/app/sets/[setCode]/WinnersLosersBoard.tsx
@@ -4,6 +4,7 @@ import { useMemo } from "react";
 import type { SetCardPerf } from "@/lib/db";
 import { fmtAUD } from "@/lib/utils";
 import { cardHref } from "@/lib/utils";
+import { CardThumb } from "@/app/CardThumb";
 
 const RARITY_COLOR: Record<string, string> = {
   mythic: "text-orange-400",
@@ -24,9 +25,13 @@ const TOP_N = 8;
 function CardRow({
   card,
   isGainer,
+  setCode,
+  setName,
 }: {
   card: SetCardPerf;
   isGainer: boolean;
+  setCode: string;
+  setName: string;
 }) {
   const pct = card.pct_change != null ? parseFloat(card.pct_change) : null;
   const first = card.first_price != null ? parseFloat(card.first_price) : null;
@@ -36,23 +41,15 @@ function CardRow({
 
   return (
     <a
-      href={cardHref(card.slug, card.card_id)}
+      href={cardHref(card.slug, card.card_id, { code: setCode, name: setName })}
       className="group flex items-center gap-2 px-3 py-2 rounded-lg hover:bg-muted transition-colors"
     >
       {/* Card thumbnail */}
-      {card.image_uri ? (
-        // eslint-disable-next-line @next/next/no-img-element
-        <img
-          src={card.image_uri}
-          alt={card.name}
-          width={28}
-          height={39}
-          className="rounded shrink-0 opacity-90 group-hover:opacity-100 transition-opacity"
-          loading="lazy"
-        />
-      ) : (
-        <div className="w-7 h-10 rounded bg-subtle shrink-0" />
-      )}
+      <CardThumb
+        imageUri={card.image_uri}
+        alt={card.name}
+        className="w-7 h-10 opacity-90 group-hover:opacity-100 transition-opacity"
+      />
 
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-1.5">
@@ -99,9 +96,11 @@ function CardRow({
 export function WinnersLosersBoard({
   cardPerf,
   setCode,
+  setName,
 }: {
   cardPerf: SetCardPerf[];
   setCode: string;
+  setName: string;
 }) {
   const gainers = useMemo(
     () =>
@@ -147,7 +146,7 @@ export function WinnersLosersBoard({
         {gainers.length > 0 ? (
           <div className="divide-y divide-subtle/30 py-1">
             {gainers.map((card) => (
-              <CardRow key={card.card_id} card={card} isGainer />
+              <CardRow key={card.card_id} card={card} isGainer setCode={setCode} setName={setName} />
             ))}
           </div>
         ) : (
@@ -171,7 +170,7 @@ export function WinnersLosersBoard({
         {losers.length > 0 ? (
           <div className="divide-y divide-subtle/30 py-1">
             {losers.map((card) => (
-              <CardRow key={card.card_id} card={card} isGainer={false} />
+              <CardRow key={card.card_id} card={card} isGainer={false} setCode={setCode} setName={setName} />
             ))}
           </div>
         ) : (

--- a/apps/web/src/app/sets/[setCode]/WinnersLosersBoard.tsx
+++ b/apps/web/src/app/sets/[setCode]/WinnersLosersBoard.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import { useMemo } from "react";
+import type { SetCardPerf } from "@/lib/db";
+import { fmtAUD } from "@/lib/utils";
+import { cardHref } from "@/lib/utils";
+
+const RARITY_COLOR: Record<string, string> = {
+  mythic: "text-orange-400",
+  rare: "text-yellow-400",
+  uncommon: "text-blue-300",
+  common: "text-cream-dim",
+};
+
+const RARITY_LABEL: Record<string, string> = {
+  mythic: "M",
+  rare: "R",
+  uncommon: "U",
+  common: "C",
+};
+
+const TOP_N = 8;
+
+function CardRow({
+  card,
+  isGainer,
+}: {
+  card: SetCardPerf;
+  isGainer: boolean;
+}) {
+  const pct = card.pct_change != null ? parseFloat(card.pct_change) : null;
+  const first = card.first_price != null ? parseFloat(card.first_price) : null;
+  const current = card.current_price != null ? parseFloat(card.current_price) : null;
+  const maxBarPct = 100;
+  const barWidth = pct != null ? Math.min(Math.abs(pct), maxBarPct) : 0;
+
+  return (
+    <a
+      href={cardHref(card.slug, card.card_id)}
+      className="group flex items-center gap-2 px-3 py-2 rounded-lg hover:bg-muted transition-colors"
+    >
+      {/* Card thumbnail */}
+      {card.image_uri ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={card.image_uri}
+          alt={card.name}
+          width={28}
+          height={39}
+          className="rounded shrink-0 opacity-90 group-hover:opacity-100 transition-opacity"
+          loading="lazy"
+        />
+      ) : (
+        <div className="w-7 h-10 rounded bg-subtle shrink-0" />
+      )}
+
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-1.5">
+          <span
+            className={`text-[9px] font-bold rounded px-1 py-0.5 bg-subtle ${RARITY_COLOR[card.rarity] ?? "text-cream-dim"}`}
+          >
+            {RARITY_LABEL[card.rarity] ?? "?"}
+          </span>
+          <span className="text-xs font-medium text-cream truncate group-hover:text-accent transition-colors">
+            {card.name}
+          </span>
+        </div>
+        {/* Bar */}
+        <div className="mt-1 h-1 rounded-full bg-subtle/50 overflow-hidden">
+          <div
+            className={`h-full rounded-full transition-all ${
+              isGainer ? "bg-red-500/70" : "bg-green-500/70"
+            }`}
+            style={{ width: `${barWidth}%` }}
+          />
+        </div>
+      </div>
+
+      <div className="text-right shrink-0">
+        <div
+          className={`text-xs font-bold ${
+            isGainer ? "text-red-400" : "text-green-400"
+          }`}
+        >
+          {pct != null
+            ? `${isGainer ? "+" : ""}${pct.toFixed(0)}%`
+            : "—"}
+        </div>
+        <div className="text-[10px] text-cream-dim/40">
+          {first != null && current != null
+            ? `${fmtAUD(first)} → ${fmtAUD(current)}`
+            : "—"}
+        </div>
+      </div>
+    </a>
+  );
+}
+
+export function WinnersLosersBoard({
+  cardPerf,
+  setCode,
+}: {
+  cardPerf: SetCardPerf[];
+  setCode: string;
+}) {
+  const gainers = useMemo(
+    () =>
+      [...cardPerf]
+        .filter((c) => c.pct_change != null && parseFloat(c.pct_change) > 0)
+        .sort((a, b) => parseFloat(b.pct_change!) - parseFloat(a.pct_change!))
+        .slice(0, TOP_N),
+    [cardPerf]
+  );
+
+  const losers = useMemo(
+    () =>
+      [...cardPerf]
+        .filter((c) => c.pct_change != null && parseFloat(c.pct_change) < 0)
+        .sort((a, b) => parseFloat(a.pct_change!) - parseFloat(b.pct_change!))
+        .slice(0, TOP_N),
+    [cardPerf]
+  );
+
+  const noMovement = gainers.length === 0 && losers.length === 0;
+
+  if (noMovement) {
+    return (
+      <div className="rounded-lg border border-subtle bg-surface p-6 text-center text-sm text-cream-dim/40">
+        Price history is too new to compute changes yet.
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid sm:grid-cols-2 gap-4">
+      {/* Gainers */}
+      <div className="rounded-xl border border-red-900/30 bg-surface overflow-hidden">
+        <div className="px-3 py-2 border-b border-red-900/20 bg-red-900/10 flex items-center gap-2">
+          <span className="text-red-400 font-bold text-sm">↑</span>
+          <span className="text-xs font-semibold text-cream">
+            Biggest Gainers
+          </span>
+          <span className="text-[10px] text-cream-dim/40 ml-auto">
+            since release
+          </span>
+        </div>
+        {gainers.length > 0 ? (
+          <div className="divide-y divide-subtle/30 py-1">
+            {gainers.map((card) => (
+              <CardRow key={card.card_id} card={card} isGainer />
+            ))}
+          </div>
+        ) : (
+          <div className="px-3 py-6 text-center text-xs text-cream-dim/40">
+            No cards have gained value yet
+          </div>
+        )}
+      </div>
+
+      {/* Losers */}
+      <div className="rounded-xl border border-green-900/30 bg-surface overflow-hidden">
+        <div className="px-3 py-2 border-b border-green-900/20 bg-green-900/10 flex items-center gap-2">
+          <span className="text-green-400 font-bold text-sm">↓</span>
+          <span className="text-xs font-semibold text-cream">
+            Biggest Drops
+          </span>
+          <span className="text-[10px] text-cream-dim/40 ml-auto">
+            best buying opportunities
+          </span>
+        </div>
+        {losers.length > 0 ? (
+          <div className="divide-y divide-subtle/30 py-1">
+            {losers.map((card) => (
+              <CardRow key={card.card_id} card={card} isGainer={false} />
+            ))}
+          </div>
+        ) : (
+          <div className="px-3 py-6 text-center text-xs text-cream-dim/40">
+            No cards have dropped in value yet
+          </div>
+        )}
+      </div>
+
+      {/* Bottom share nudge */}
+      <div className="sm:col-span-2 text-[11px] text-cream-dim/40 text-center">
+        Prices are cheapest non-foil in-stock AU store price vs first recorded price ·{" "}
+        <a href={`/sets/${setCode}`} className="hover:text-accent transition-colors">
+          Share this page
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/sets/[setCode]/opengraph-image.tsx
+++ b/apps/web/src/app/sets/[setCode]/opengraph-image.tsx
@@ -1,0 +1,368 @@
+import { ImageResponse } from "next/og";
+import {
+  getSetMetadata,
+  getSetPriceTimeline,
+  getSetCardPerformance,
+} from "@/lib/db";
+
+export const runtime = "nodejs";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+async function fetchSvgAsDataUrl(url: string): Promise<string | null> {
+  try {
+    const res = await fetch(url);
+    if (!res.ok) return null;
+    const buf = await res.arrayBuffer();
+    return `data:image/svg+xml;base64,${Buffer.from(buf).toString("base64")}`;
+  } catch {
+    return null;
+  }
+}
+
+export default async function SetOgImage({
+  params,
+}: {
+  params: Promise<{ setCode: string }>;
+}) {
+  const { setCode } = await params;
+
+  const [meta, timeline, cardPerf] = await Promise.all([
+    getSetMetadata(setCode),
+    getSetPriceTimeline(setCode),
+    getSetCardPerformance(setCode),
+  ]);
+
+  const setName = meta?.set_name ?? "MTG Set";
+  const setIconUrl = `https://svgs.scryfall.io/sets/${setCode}.svg`;
+  const iconData = await fetchSvgAsDataUrl(setIconUrl);
+
+  // Compute key stats
+  const currentValue =
+    timeline.length > 0
+      ? parseFloat(timeline[timeline.length - 1].total_value)
+      : null;
+  const firstValue =
+    timeline.length > 1 ? parseFloat(timeline[0].total_value) : null;
+  const changePct =
+    firstValue && currentValue
+      ? ((currentValue - firstValue) / firstValue) * 100
+      : null;
+
+  const topGainer =
+    cardPerf.length > 0 && cardPerf[0].pct_change != null
+      ? cardPerf[0]
+      : null;
+  const topLoser =
+    cardPerf.length > 0
+      ? [...cardPerf]
+          .filter((c) => c.pct_change != null && parseFloat(c.pct_change) < 0)
+          .sort((a, b) => parseFloat(a.pct_change!) - parseFloat(b.pct_change!))
+          .at(0) ?? null
+      : null;
+
+  const changeLabel =
+    changePct != null
+      ? `${changePct > 0 ? "+" : ""}${changePct.toFixed(0)}% since release`
+      : null;
+  const changeColor =
+    changePct != null && changePct < 0 ? "#4ade80" : "#f87171";
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          background: "#12100e",
+          fontFamily: "sans-serif",
+          padding: "0",
+        }}
+      >
+        {/* Top accent bar */}
+        <div
+          style={{
+            height: 5,
+            background: "linear-gradient(90deg, #257180, #FD8B51)",
+            display: "flex",
+          }}
+        />
+
+        <div style={{ display: "flex", flex: 1, padding: "52px 64px 48px" }}>
+          {/* Left column */}
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              flex: 1,
+              paddingRight: 48,
+            }}
+          >
+            {/* Label */}
+            <div
+              style={{
+                display: "flex",
+                fontSize: 15,
+                color: "#5ce0d8",
+                letterSpacing: "0.12em",
+                textTransform: "uppercase",
+                marginBottom: 20,
+              }}
+            >
+              SCRYMARKET · AU Price Story
+            </div>
+
+            {/* Set icon + name */}
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 20,
+                marginBottom: 28,
+              }}
+            >
+              {iconData ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={iconData}
+                  width={56}
+                  height={56}
+                  style={{ opacity: 0.85 }}
+                  alt={setName}
+                />
+              ) : null}
+              <div
+                style={{
+                  fontSize: setName.length > 24 ? 38 : 48,
+                  fontWeight: 700,
+                  color: "#e8dece",
+                  lineHeight: 1.15,
+                  display: "flex",
+                }}
+              >
+                {setName}
+              </div>
+            </div>
+
+            {/* Stats row */}
+            <div style={{ display: "flex", gap: 24, marginBottom: 32 }}>
+              {currentValue != null && (
+                <div
+                  style={{
+                    display: "flex",
+                    flexDirection: "column",
+                    background: "rgba(253,139,81,0.12)",
+                    border: "1px solid rgba(253,139,81,0.25)",
+                    borderRadius: 10,
+                    padding: "14px 20px",
+                  }}
+                >
+                  <span
+                    style={{
+                      fontSize: 11,
+                      color: "#8a8070",
+                      letterSpacing: "0.1em",
+                      textTransform: "uppercase",
+                      display: "flex",
+                      marginBottom: 4,
+                    }}
+                  >
+                    Set value
+                  </span>
+                  <span
+                    style={{
+                      fontSize: 30,
+                      fontWeight: 700,
+                      color: "#FD8B51",
+                      display: "flex",
+                    }}
+                  >
+                    ${currentValue.toFixed(0)} AUD
+                  </span>
+                </div>
+              )}
+
+              {changeLabel && (
+                <div
+                  style={{
+                    display: "flex",
+                    flexDirection: "column",
+                    background: "rgba(255,255,255,0.05)",
+                    border: "1px solid rgba(255,255,255,0.1)",
+                    borderRadius: 10,
+                    padding: "14px 20px",
+                  }}
+                >
+                  <span
+                    style={{
+                      fontSize: 11,
+                      color: "#8a8070",
+                      letterSpacing: "0.1em",
+                      textTransform: "uppercase",
+                      display: "flex",
+                      marginBottom: 4,
+                    }}
+                  >
+                    Change
+                  </span>
+                  <span
+                    style={{
+                      fontSize: 30,
+                      fontWeight: 700,
+                      color: changeColor,
+                      display: "flex",
+                    }}
+                  >
+                    {changeLabel}
+                  </span>
+                </div>
+              )}
+            </div>
+
+            {/* Card callouts */}
+            <div style={{ display: "flex", gap: 16 }}>
+              {topGainer && (
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 10,
+                    background: "rgba(239,68,68,0.08)",
+                    border: "1px solid rgba(239,68,68,0.2)",
+                    borderRadius: 8,
+                    padding: "8px 14px",
+                  }}
+                >
+                  <span style={{ color: "#f87171", fontSize: 13, display: "flex" }}>↑</span>
+                  <span style={{ color: "#e8dece", fontSize: 13, display: "flex" }}>
+                    {topGainer.name}
+                  </span>
+                  <span
+                    style={{
+                      color: "#f87171",
+                      fontSize: 13,
+                      fontWeight: 700,
+                      display: "flex",
+                    }}
+                  >
+                    +{parseFloat(topGainer.pct_change!).toFixed(0)}%
+                  </span>
+                </div>
+              )}
+              {topLoser && (
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 10,
+                    background: "rgba(74,222,128,0.08)",
+                    border: "1px solid rgba(74,222,128,0.2)",
+                    borderRadius: 8,
+                    padding: "8px 14px",
+                  }}
+                >
+                  <span style={{ color: "#4ade80", fontSize: 13, display: "flex" }}>↓</span>
+                  <span style={{ color: "#e8dece", fontSize: 13, display: "flex" }}>
+                    {topLoser.name}
+                  </span>
+                  <span
+                    style={{
+                      color: "#4ade80",
+                      fontSize: 13,
+                      fontWeight: 700,
+                      display: "flex",
+                    }}
+                  >
+                    {parseFloat(topLoser.pct_change!).toFixed(0)}%
+                  </span>
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Right: card count */}
+          {meta && (
+            <div
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                justifyContent: "center",
+                alignItems: "center",
+                width: 160,
+                gap: 12,
+              }}
+            >
+              <div
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  alignItems: "center",
+                  background: "rgba(37,113,128,0.15)",
+                  border: "1px solid rgba(37,113,128,0.3)",
+                  borderRadius: 12,
+                  padding: "16px 20px",
+                  textAlign: "center",
+                }}
+              >
+                <span
+                  style={{
+                    fontSize: 40,
+                    fontWeight: 700,
+                    color: "#31929f",
+                    display: "flex",
+                    lineHeight: 1,
+                  }}
+                >
+                  {meta.unique_cards}
+                </span>
+                <span
+                  style={{
+                    fontSize: 11,
+                    color: "#6a8a90",
+                    marginTop: 4,
+                    display: "flex",
+                    textTransform: "uppercase",
+                    letterSpacing: "0.08em",
+                  }}
+                >
+                  cards tracked
+                </span>
+              </div>
+              <div
+                style={{
+                  fontSize: 11,
+                  color: "#4a4030",
+                  textAlign: "center",
+                  display: "flex",
+                }}
+              >
+                across AU stores
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Bottom bar */}
+        <div
+          style={{
+            display: "flex",
+            padding: "12px 64px",
+            borderTop: "1px solid rgba(255,255,255,0.06)",
+            justifyContent: "space-between",
+            alignItems: "center",
+          }}
+        >
+          <span style={{ fontSize: 13, color: "#4a4030", display: "flex" }}>
+            scrymarket.com.au
+          </span>
+          <span style={{ fontSize: 13, color: "#4a4030", display: "flex" }}>
+            AU MTG price tracker · {meta?.mythic_count ?? 0}M {meta?.rare_count ?? 0}R
+          </span>
+        </div>
+      </div>
+    ),
+    { ...size }
+  );
+}

--- a/apps/web/src/app/sets/[setCode]/opengraph-image.tsx
+++ b/apps/web/src/app/sets/[setCode]/opengraph-image.tsx
@@ -29,8 +29,8 @@ export default async function SetOgImage({
 
   const [meta, timeline, cardPerf] = await Promise.all([
     getSetMetadata(setCode),
-    getSetPriceTimeline(setCode),
-    getSetCardPerformance(setCode),
+    getSetPriceTimeline([setCode]),
+    getSetCardPerformance([setCode]),
   ]);
 
   const setName = meta?.set_name ?? "MTG Set";
@@ -111,7 +111,7 @@ export default async function SetOgImage({
                 marginBottom: 20,
               }}
             >
-              SCRYMARKET · AU Price Story
+              SCRYMARKET · AU Market Breakdown
             </div>
 
             {/* Set icon + name */}

--- a/apps/web/src/app/sets/[setCode]/page.tsx
+++ b/apps/web/src/app/sets/[setCode]/page.tsx
@@ -5,11 +5,12 @@ import {
   getSetPriceTimeline,
   getSetCardPerformance,
   getSetRarityBreakdown,
-  getSetStoreComparison,
+  getSetReprintCards,
+  getChildSets,
 } from "@/lib/db";
 import { SetDataStory } from "./SetDataStory";
 
-export const revalidate = 3600;
+export const dynamic = "force-dynamic";
 
 export async function generateMetadata({
   params,
@@ -21,15 +22,15 @@ export async function generateMetadata({
   if (!meta) return { title: "Set Not Found | Scrymarket" };
 
   return {
-    title: `${meta.set_name} Price Story | Scrymarket`,
-    description: `Track ${meta.set_name} card prices across Australian stores. See winners, losers, and the full AU price story since release.`,
+    title: `${meta.set_name} — AU Market Breakdown | Scrymarket`,
+    description: `Track ${meta.set_name} card prices across Australian stores. See winners, losers, and the full AU market breakdown since release.`,
     openGraph: {
-      title: `${meta.set_name} — AU Price Story`,
+      title: `${meta.set_name} — AU Market Breakdown`,
       description: `${meta.unique_cards} cards tracked across AU stores. See which cards spiked, which crashed, and the full market timeline.`,
     },
     twitter: {
       card: "summary_large_image",
-      title: `${meta.set_name} — AU Price Story | Scrymarket`,
+      title: `${meta.set_name} — AU Market Breakdown | Scrymarket`,
       description: `${meta.unique_cards} cards. Full AU price data since release.`,
     },
   };
@@ -37,29 +38,53 @@ export async function generateMetadata({
 
 export default async function SetPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ setCode: string }>;
+  searchParams: Promise<{ subsets?: string }>;
 }) {
   const { setCode } = await params;
+  const { subsets: subsetsParam } = await searchParams;
 
-  const [meta, timeline, cardPerf, rarityBreakdown, storeComparison] =
-    await Promise.all([
-      getSetMetadata(setCode),
-      getSetPriceTimeline(setCode),
-      getSetCardPerformance(setCode),
-      getSetRarityBreakdown(setCode),
-      getSetStoreComparison(setCode),
-    ]);
-
+  const [meta, allChildSets] = await Promise.all([
+    getSetMetadata(setCode),
+    getChildSets(setCode),
+  ]);
   if (!meta) notFound();
+
+  // Tokens are never included in data or shown in the toggle UI
+  const childSets = allChildSets.filter((s) => s.set_type !== "token");
+  const validChildCodes = new Set(childSets.map((s) => s.set_code));
+
+  // Default: include ALL non-token children.
+  // When ?subsets param is present, use that explicit list (empty string = none).
+  let activeSubsets: string[];
+  if (subsetsParam === undefined) {
+    activeSubsets = childSets.map((s) => s.set_code);
+  } else {
+    activeSubsets = subsetsParam
+      ? subsetsParam.split(",").filter((c) => validChildCodes.has(c))
+      : [];
+  }
+  const allSetCodes = [setCode, ...activeSubsets];
+
+  const [timeline, cardPerf, rarityBreakdown, reprintCards] =
+    await Promise.all([
+      getSetPriceTimeline(allSetCodes),
+      getSetCardPerformance(allSetCodes),
+      getSetRarityBreakdown(allSetCodes),
+      getSetReprintCards(setCode),
+    ]);
 
   return (
     <SetDataStory
-      meta={meta!}
+      meta={meta}
       timeline={timeline}
       cardPerf={cardPerf}
       rarityBreakdown={rarityBreakdown}
-      storeComparison={storeComparison}
+      reprintCards={reprintCards}
+      childSets={childSets}
+      activeSubsets={activeSubsets}
     />
   );
 }

--- a/apps/web/src/app/sets/[setCode]/page.tsx
+++ b/apps/web/src/app/sets/[setCode]/page.tsx
@@ -1,0 +1,65 @@
+import { notFound } from "next/navigation";
+import type { Metadata } from "next";
+import {
+  getSetMetadata,
+  getSetPriceTimeline,
+  getSetCardPerformance,
+  getSetRarityBreakdown,
+  getSetStoreComparison,
+} from "@/lib/db";
+import { SetDataStory } from "./SetDataStory";
+
+export const revalidate = 3600;
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ setCode: string }>;
+}): Promise<Metadata> {
+  const { setCode } = await params;
+  const meta = await getSetMetadata(setCode);
+  if (!meta) return { title: "Set Not Found | Scrymarket" };
+
+  return {
+    title: `${meta.set_name} Price Story | Scrymarket`,
+    description: `Track ${meta.set_name} card prices across Australian stores. See winners, losers, and the full AU price story since release.`,
+    openGraph: {
+      title: `${meta.set_name} — AU Price Story`,
+      description: `${meta.unique_cards} cards tracked across AU stores. See which cards spiked, which crashed, and the full market timeline.`,
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: `${meta.set_name} — AU Price Story | Scrymarket`,
+      description: `${meta.unique_cards} cards. Full AU price data since release.`,
+    },
+  };
+}
+
+export default async function SetPage({
+  params,
+}: {
+  params: Promise<{ setCode: string }>;
+}) {
+  const { setCode } = await params;
+
+  const [meta, timeline, cardPerf, rarityBreakdown, storeComparison] =
+    await Promise.all([
+      getSetMetadata(setCode),
+      getSetPriceTimeline(setCode),
+      getSetCardPerformance(setCode),
+      getSetRarityBreakdown(setCode),
+      getSetStoreComparison(setCode),
+    ]);
+
+  if (!meta) notFound();
+
+  return (
+    <SetDataStory
+      meta={meta!}
+      timeline={timeline}
+      cardPerf={cardPerf}
+      rarityBreakdown={rarityBreakdown}
+      storeComparison={storeComparison}
+    />
+  );
+}

--- a/apps/web/src/app/sets/page.tsx
+++ b/apps/web/src/app/sets/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { getSetList } from "@/lib/db";
 
-export const revalidate = 3600;
+export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
   title: "Set Releases | Scrymarket",

--- a/apps/web/src/app/sets/page.tsx
+++ b/apps/web/src/app/sets/page.tsx
@@ -1,108 +1,40 @@
-import type { Metadata } from "next";
-import { getSetList } from "@/lib/db";
+export const revalidate = 3600;
 
-export const dynamic = "force-dynamic";
+import type { Metadata } from "next";
+import { getSetList, getTopMovers } from "@/lib/db";
+import { SetsListClient } from "./SetsListClient";
+import { MarketPulse } from "./MarketPulse";
 
 export const metadata: Metadata = {
   title: "Set Releases | Scrymarket",
   description: "Browse MTG set releases and track price movements across Australian stores.",
 };
 
-function formatDate(dateStr: string) {
-  return new Date(dateStr).toLocaleDateString("en-AU", {
-    month: "short",
-    year: "numeric",
-  });
-}
+export default async function SetsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ all?: string }>;
+}) {
+  const { all } = await searchParams;
+  const showAll = all === "1";
+  const sets = await getSetList(showAll ? 20 : 2);
 
-export default async function SetsPage() {
-  const sets = await getSetList();
+  const [movers7, movers14, movers30] = await Promise.all([
+    getTopMovers(7),
+    getTopMovers(14),
+    getTopMovers(30),
+  ]);
 
   return (
     <div className="max-w-4xl mx-auto">
-      <div className="mb-8">
-        <h1 className="text-2xl font-bold text-cream mb-1">Set Releases</h1>
-        <p className="text-sm text-cream-dim/60">
-          Price data across {sets.length} sets stocked in Australian stores.
-          Click a set to see the full price story.
-        </p>
-      </div>
+      <MarketPulse movers7={movers7} movers14={movers14} movers30={movers30} />
 
-      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-        {sets.map((set) => {
-          const value = set.total_value ? parseFloat(set.total_value) : null;
-          const coverage =
-            set.unique_cards > 0
-              ? Math.round((set.in_stock_cards / set.unique_cards) * 100)
-              : 0;
-
-          return (
-            <a
-              key={set.set_code}
-              href={`/sets/${set.set_code}`}
-              className="group block rounded-lg border border-subtle bg-surface p-4 hover:border-accent-border hover:bg-accent-muted transition-colors"
-            >
-              <div className="flex items-start gap-3">
-                {/* Set icon */}
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img
-                  src={`https://svgs.scryfall.io/sets/${set.set_code}.svg`}
-                  alt={set.set_name}
-                  width={28}
-                  height={28}
-                  className="shrink-0 mt-0.5 opacity-70 group-hover:opacity-100 transition-opacity"
-                  style={{ filter: "invert(60%) sepia(20%) saturate(300%) hue-rotate(160deg)" }}
-                  onError={(e) => { (e.target as HTMLImageElement).style.display = "none"; }}
-                />
-                <div className="min-w-0 flex-1">
-                  <div className="font-medium text-cream text-sm leading-tight truncate">
-                    {set.set_name}
-                  </div>
-                  <div className="text-[11px] text-cream-dim/50 mt-0.5 uppercase tracking-wide">
-                    {set.set_code} · {formatDate(set.released_at)}
-                  </div>
-                </div>
-              </div>
-
-              <div className="mt-3 flex items-end justify-between">
-                <div>
-                  <div className="text-[10px] text-cream-dim/40 uppercase tracking-wider">
-                    Set value
-                  </div>
-                  <div className="text-lg font-bold text-price">
-                    {value != null ? `$${value.toFixed(0)}` : "—"}
-                    <span className="text-[10px] text-cream-dim/40 font-normal ml-1">AUD</span>
-                  </div>
-                </div>
-                <div className="text-right">
-                  <div className="text-[10px] text-cream-dim/40 uppercase tracking-wider">
-                    Coverage
-                  </div>
-                  <div className="text-sm font-semibold text-cream-dim">
-                    {coverage}%
-                    <span className="text-[10px] text-cream-dim/40 font-normal ml-1">
-                      ({set.in_stock_cards}/{set.unique_cards})
-                    </span>
-                  </div>
-                </div>
-              </div>
-
-              {/* Coverage bar */}
-              <div className="mt-2 h-0.5 rounded-full bg-subtle overflow-hidden">
-                <div
-                  className="h-full bg-accent rounded-full transition-all"
-                  style={{ width: `${coverage}%` }}
-                />
-              </div>
-            </a>
-          );
-        })}
-      </div>
-
-      {sets.length === 0 && (
+      {sets.length === 0 ? (
         <div className="text-center py-16 text-cream-dim/40 text-sm">
-          No sets with AU store data yet. Check back after the next scrape run.
+          No sets found. Check back after the next scrape run.
         </div>
+      ) : (
+        <SetsListClient sets={sets} showAll={showAll} />
       )}
     </div>
   );

--- a/apps/web/src/app/sets/page.tsx
+++ b/apps/web/src/app/sets/page.tsx
@@ -1,0 +1,109 @@
+import type { Metadata } from "next";
+import { getSetList } from "@/lib/db";
+
+export const revalidate = 3600;
+
+export const metadata: Metadata = {
+  title: "Set Releases | Scrymarket",
+  description: "Browse MTG set releases and track price movements across Australian stores.",
+};
+
+function formatDate(dateStr: string) {
+  return new Date(dateStr).toLocaleDateString("en-AU", {
+    month: "short",
+    year: "numeric",
+  });
+}
+
+export default async function SetsPage() {
+  const sets = await getSetList();
+
+  return (
+    <div className="max-w-4xl mx-auto">
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold text-cream mb-1">Set Releases</h1>
+        <p className="text-sm text-cream-dim/60">
+          Price data across {sets.length} sets stocked in Australian stores.
+          Click a set to see the full price story.
+        </p>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {sets.map((set) => {
+          const value = set.total_value ? parseFloat(set.total_value) : null;
+          const coverage =
+            set.unique_cards > 0
+              ? Math.round((set.in_stock_cards / set.unique_cards) * 100)
+              : 0;
+
+          return (
+            <a
+              key={set.set_code}
+              href={`/sets/${set.set_code}`}
+              className="group block rounded-lg border border-subtle bg-surface p-4 hover:border-accent-border hover:bg-accent-muted transition-colors"
+            >
+              <div className="flex items-start gap-3">
+                {/* Set icon */}
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={`https://svgs.scryfall.io/sets/${set.set_code}.svg`}
+                  alt={set.set_name}
+                  width={28}
+                  height={28}
+                  className="shrink-0 mt-0.5 opacity-70 group-hover:opacity-100 transition-opacity"
+                  style={{ filter: "invert(60%) sepia(20%) saturate(300%) hue-rotate(160deg)" }}
+                  onError={(e) => { (e.target as HTMLImageElement).style.display = "none"; }}
+                />
+                <div className="min-w-0 flex-1">
+                  <div className="font-medium text-cream text-sm leading-tight truncate">
+                    {set.set_name}
+                  </div>
+                  <div className="text-[11px] text-cream-dim/50 mt-0.5 uppercase tracking-wide">
+                    {set.set_code} · {formatDate(set.released_at)}
+                  </div>
+                </div>
+              </div>
+
+              <div className="mt-3 flex items-end justify-between">
+                <div>
+                  <div className="text-[10px] text-cream-dim/40 uppercase tracking-wider">
+                    Set value
+                  </div>
+                  <div className="text-lg font-bold text-price">
+                    {value != null ? `$${value.toFixed(0)}` : "—"}
+                    <span className="text-[10px] text-cream-dim/40 font-normal ml-1">AUD</span>
+                  </div>
+                </div>
+                <div className="text-right">
+                  <div className="text-[10px] text-cream-dim/40 uppercase tracking-wider">
+                    Coverage
+                  </div>
+                  <div className="text-sm font-semibold text-cream-dim">
+                    {coverage}%
+                    <span className="text-[10px] text-cream-dim/40 font-normal ml-1">
+                      ({set.in_stock_cards}/{set.unique_cards})
+                    </span>
+                  </div>
+                </div>
+              </div>
+
+              {/* Coverage bar */}
+              <div className="mt-2 h-0.5 rounded-full bg-subtle overflow-hidden">
+                <div
+                  className="h-full bg-accent rounded-full transition-all"
+                  style={{ width: `${coverage}%` }}
+                />
+              </div>
+            </a>
+          );
+        })}
+      </div>
+
+      {sets.length === 0 && (
+        <div className="text-center py-16 text-cream-dim/40 text-sm">
+          No sets with AU store data yet. Check back after the next scrape run.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/lib/db.ts
+++ b/apps/web/src/lib/db.ts
@@ -252,6 +252,266 @@ export async function getStores(): Promise<StoreRow[]> {
   `;
 }
 
+// ─── Set queries ─────────────────────────────────────────────────────────────
+
+export type SetSummary = {
+  set_code: string;
+  set_name: string;
+  released_at: string;
+  unique_cards: number;
+  in_stock_cards: number;
+  total_value: string | null;
+};
+
+/** All sets that have >20 unique cards and at least some AU store inventory. */
+export async function getSetList(): Promise<SetSummary[]> {
+  return sql<SetSummary[]>`
+    WITH card_prices AS (
+      SELECT
+        p.set_code,
+        p.card_id,
+        MIN(sp.price_aud::numeric) AS min_price
+      FROM printings p
+      JOIN store_prices sp ON sp.printing_id = p.id
+      WHERE p.is_foil = false
+        AND sp.in_stock = true
+        AND sp.price_type = 'sell'
+      GROUP BY p.set_code, p.card_id
+    )
+    SELECT
+      p.set_code,
+      p.set_name,
+      MIN(p.released_at)::text AS released_at,
+      COUNT(DISTINCT p.card_id)::int AS unique_cards,
+      COUNT(DISTINCT cp.card_id)::int AS in_stock_cards,
+      SUM(cp.min_price)::text AS total_value
+    FROM printings p
+    LEFT JOIN card_prices cp ON cp.set_code = p.set_code AND cp.card_id = p.card_id
+    WHERE p.is_foil = false
+    GROUP BY p.set_code, p.set_name
+    HAVING COUNT(DISTINCT p.card_id) > 20
+      AND COUNT(DISTINCT cp.card_id) > 5
+    ORDER BY MIN(p.released_at) DESC
+    LIMIT 50
+  `;
+}
+
+export type SetMetadata = {
+  set_code: string;
+  set_name: string;
+  released_at: string;
+  unique_cards: number;
+  total_printings: number;
+  mythic_count: number;
+  rare_count: number;
+  uncommon_count: number;
+  common_count: number;
+};
+
+/** Header stats for a single set page. */
+export async function getSetMetadata(setCode: string): Promise<SetMetadata | null> {
+  const rows = await sql<SetMetadata[]>`
+    SELECT
+      set_code,
+      set_name,
+      MIN(released_at)::text AS released_at,
+      COUNT(DISTINCT card_id)::int AS unique_cards,
+      COUNT(*)::int AS total_printings,
+      COUNT(*) FILTER (WHERE rarity = 'mythic' AND is_foil = false)::int AS mythic_count,
+      COUNT(*) FILTER (WHERE rarity = 'rare' AND is_foil = false)::int AS rare_count,
+      COUNT(*) FILTER (WHERE rarity = 'uncommon' AND is_foil = false)::int AS uncommon_count,
+      COUNT(*) FILTER (WHERE rarity = 'common' AND is_foil = false)::int AS common_count
+    FROM printings
+    WHERE set_code = ${setCode}
+    GROUP BY set_code, set_name
+  `;
+  return rows[0] ?? null;
+}
+
+export type SetPriceTimelinePoint = {
+  date: string;
+  total_value: string;
+  card_count: number;
+};
+
+/** Daily total set value (sum of cheapest non-foil price per unique card). */
+export async function getSetPriceTimeline(setCode: string): Promise<SetPriceTimelinePoint[]> {
+  return sql<SetPriceTimelinePoint[]>`
+    WITH daily_card_prices AS (
+      SELECT
+        ph.recorded_at,
+        p.card_id,
+        MIN(ph.price_aud::numeric) AS min_price
+      FROM price_history ph
+      JOIN printings p ON p.id = ph.printing_id
+      WHERE p.set_code = ${setCode}
+        AND ph.price_type = 'sell'
+        AND p.is_foil = false
+      GROUP BY ph.recorded_at, p.card_id
+    )
+    SELECT
+      recorded_at::text AS date,
+      SUM(min_price)::text AS total_value,
+      COUNT(*)::int AS card_count
+    FROM daily_card_prices
+    GROUP BY recorded_at
+    ORDER BY recorded_at
+  `;
+}
+
+export type SetCardPerf = {
+  card_id: string;
+  name: string;
+  slug: string | null;
+  rarity: string;
+  image_uri: string | null;
+  first_price: string | null;
+  current_price: string | null;
+  pct_change: string | null;
+};
+
+/**
+ * Per-card price performance: first recorded price vs current in-stock price.
+ * Ordered by pct_change DESC (biggest gainers first).
+ */
+export async function getSetCardPerformance(setCode: string): Promise<SetCardPerf[]> {
+  return sql<SetCardPerf[]>`
+    WITH first_seen AS (
+      SELECT
+        p.card_id,
+        MIN(ph.recorded_at) AS first_date
+      FROM price_history ph
+      JOIN printings p ON p.id = ph.printing_id
+      WHERE p.set_code = ${setCode}
+        AND ph.price_type = 'sell'
+        AND p.is_foil = false
+      GROUP BY p.card_id
+    ),
+    first_price AS (
+      SELECT
+        fs.card_id,
+        MIN(ph.price_aud::numeric) AS price
+      FROM first_seen fs
+      JOIN printings p ON p.card_id = fs.card_id
+        AND p.set_code = ${setCode}
+        AND p.is_foil = false
+      JOIN price_history ph ON ph.printing_id = p.id
+        AND ph.recorded_at = fs.first_date
+        AND ph.price_type = 'sell'
+      GROUP BY fs.card_id
+    ),
+    current_price AS (
+      SELECT
+        p.card_id,
+        MIN(sp.price_aud::numeric) AS price
+      FROM store_prices sp
+      JOIN printings p ON p.id = sp.printing_id
+      WHERE p.set_code = ${setCode}
+        AND sp.price_type = 'sell'
+        AND sp.in_stock = true
+        AND p.is_foil = false
+      GROUP BY p.card_id
+    ),
+    printing_info AS (
+      SELECT DISTINCT ON (card_id)
+        card_id,
+        rarity,
+        image_uri
+      FROM printings
+      WHERE set_code = ${setCode} AND is_foil = false
+      ORDER BY card_id, released_at ASC
+    )
+    SELECT
+      c.id AS card_id,
+      c.name,
+      c.slug,
+      pi.rarity,
+      pi.image_uri,
+      fp.price::text AS first_price,
+      cp.price::text AS current_price,
+      CASE
+        WHEN fp.price > 0
+        THEN ROUND(((cp.price - fp.price) / fp.price * 100)::numeric, 1)::text
+        ELSE NULL
+      END AS pct_change
+    FROM first_price fp
+    JOIN current_price cp ON cp.card_id = fp.card_id
+    JOIN cards c ON c.id = fp.card_id
+    JOIN printing_info pi ON pi.card_id = fp.card_id
+    ORDER BY
+      CASE WHEN fp.price > 0 THEN (cp.price - fp.price) / fp.price END DESC NULLS LAST
+  `;
+}
+
+export type SetRarityBreakdown = {
+  rarity: string;
+  card_count: number;
+  avg_price: string | null;
+  total_value: string | null;
+};
+
+/** Value distribution by rarity for in-stock non-foil cards. */
+export async function getSetRarityBreakdown(setCode: string): Promise<SetRarityBreakdown[]> {
+  return sql<SetRarityBreakdown[]>`
+    WITH card_prices AS (
+      SELECT
+        p.card_id,
+        p.rarity,
+        MIN(sp.price_aud::numeric) AS min_price
+      FROM printings p
+      JOIN store_prices sp ON sp.printing_id = p.id
+      WHERE p.set_code = ${setCode}
+        AND p.is_foil = false
+        AND sp.in_stock = true
+        AND sp.price_type = 'sell'
+      GROUP BY p.card_id, p.rarity
+    )
+    SELECT
+      rarity,
+      COUNT(*)::int AS card_count,
+      AVG(min_price)::text AS avg_price,
+      SUM(min_price)::text AS total_value
+    FROM card_prices
+    GROUP BY rarity
+    ORDER BY CASE rarity
+      WHEN 'mythic' THEN 1
+      WHEN 'rare' THEN 2
+      WHEN 'uncommon' THEN 3
+      WHEN 'common' THEN 4
+      ELSE 5
+    END
+  `;
+}
+
+export type SetStoreComparison = {
+  store_id: string;
+  store_name: string;
+  in_stock_count: number;
+  avg_price: string | null;
+  unique_cards: number;
+};
+
+/** Per-store inventory and price stats for a set. */
+export async function getSetStoreComparison(setCode: string): Promise<SetStoreComparison[]> {
+  return sql<SetStoreComparison[]>`
+    SELECT
+      s.id AS store_id,
+      s.name AS store_name,
+      COUNT(sp.id) FILTER (WHERE sp.in_stock = true)::int AS in_stock_count,
+      AVG(sp.price_aud::numeric) FILTER (WHERE sp.in_stock = true)::text AS avg_price,
+      COUNT(DISTINCT p.card_id) FILTER (WHERE sp.in_stock = true)::int AS unique_cards
+    FROM store_prices sp
+    JOIN printings p ON p.id = sp.printing_id
+    JOIN stores s ON s.id = sp.store_id
+    WHERE p.set_code = ${setCode}
+      AND sp.price_type = 'sell'
+      AND p.is_foil = false
+    GROUP BY s.id, s.name
+    HAVING COUNT(sp.id) FILTER (WHERE sp.in_stock = true) > 0
+    ORDER BY AVG(sp.price_aud::numeric) FILTER (WHERE sp.in_stock = true) ASC NULLS LAST
+  `;
+}
+
 export async function getCardSlugsForSitemap(): Promise<{ slug: string; updated_at: Date }[]> {
   return sql<{ slug: string; updated_at: Date }[]>`
     SELECT slug, updated_at

--- a/apps/web/src/lib/db.ts
+++ b/apps/web/src/lib/db.ts
@@ -258,41 +258,135 @@ export type SetSummary = {
   set_code: string;
   set_name: string;
   released_at: string;
-  unique_cards: number;
-  in_stock_cards: number;
-  total_value: string | null;
+  set_type: string | null;
+  card_count: number;
+  child_types: string | null;   // comma-separated distinct child set_types (excl. tokens)
+  set_value_aud: string | null; // pre-computed by scraper after each nightly store run
 };
 
-/** All sets that have >20 unique cards and at least some AU store inventory. */
-export async function getSetList(): Promise<SetSummary[]> {
+/**
+ * Canonical root sets ordered by release date, newest first.
+ * Single-table query on `sets` — sub-millisecond. Values are pre-computed by
+ * the scraper's updateSetValues() step after each nightly store scrape.
+ */
+export async function getSetList(yearsBack = 2): Promise<SetSummary[]> {
   return sql<SetSummary[]>`
-    WITH card_prices AS (
-      SELECT
-        p.set_code,
+    SELECT
+      s.set_code,
+      s.set_name,
+      s.released_at::text,
+      s.set_type,
+      s.card_count,
+      s.set_value_aud::text,
+      STRING_AGG(DISTINCT c.set_type, ',' ORDER BY c.set_type) AS child_types
+    FROM sets s
+    LEFT JOIN sets c ON c.parent_set_code = s.set_code
+      AND c.set_type IS NOT NULL
+      AND c.set_type != 'token'
+    WHERE s.parent_set_code IS NULL
+      AND (s.set_type IS NULL OR s.set_type = ANY(${CANONICAL_SET_TYPES}))
+      AND s.card_count > 20
+      AND s.released_at >= CURRENT_DATE - (${yearsBack} * INTERVAL '1 year')
+    GROUP BY s.set_code, s.set_name, s.released_at, s.set_type, s.card_count, s.set_value_aud
+    ORDER BY s.released_at DESC
+    LIMIT 100
+  `;
+}
+
+export type TopMover = {
+  card_id: string;
+  set_code: string;
+  set_name: string;
+  name: string;
+  slug: string | null;
+  image_uri: string | null;
+  start_price: string;
+  current_price: string;
+  pct_change: string;   // positive = up, negative = down
+  direction: "up" | "down";
+};
+
+/**
+ * Top 3 price gainers and top 3 losers globally over the last `days` days.
+ * Baseline price ≥ $2 to filter noise. Scans a (days + 14) day lookback window.
+ */
+export async function getTopMovers(days: number): Promise<TopMover[]> {
+  return sql<TopMover[]>`
+    WITH baseline AS (
+      SELECT DISTINCT ON (p.card_id)
         p.card_id,
-        MIN(sp.price_aud::numeric) AS min_price
-      FROM printings p
-      JOIN store_prices sp ON sp.printing_id = p.id
+        ph.price_aud::numeric AS price
+      FROM price_history ph
+      JOIN printings p ON p.id = ph.printing_id
+      JOIN store_prices sp_check ON sp_check.printing_id = ph.printing_id
+        AND sp_check.store_id = ph.store_id
+        AND sp_check.in_stock = true
+        AND sp_check.price_type = 'sell'
+      WHERE p.is_foil = false
+        AND ph.price_type = 'sell'
+        AND ph.recorded_at >= NOW() - (${days} * INTERVAL '1 day')
+      ORDER BY p.card_id, ph.recorded_at ASC
+    ),
+    current_price AS (
+      SELECT
+        p.card_id,
+        MIN(sp.price_aud::numeric) AS price,
+        (
+          SELECT p2.set_code FROM store_prices sp2
+          JOIN printings p2 ON p2.id = sp2.printing_id
+          WHERE p2.card_id = p.card_id
+            AND p2.is_foil = false
+            AND sp2.in_stock = true
+            AND sp2.price_type = 'sell'
+          ORDER BY sp2.price_aud ASC LIMIT 1
+        ) AS set_code
+      FROM store_prices sp
+      JOIN printings p ON p.id = sp.printing_id
       WHERE p.is_foil = false
         AND sp.in_stock = true
         AND sp.price_type = 'sell'
-      GROUP BY p.set_code, p.card_id
+      GROUP BY p.card_id
+    ),
+    movers AS (
+      SELECT
+        cp.set_code,
+        b.card_id,
+        b.price AS start_price,
+        cp.price AS current_price,
+        ROUND(((cp.price - b.price) / b.price * 100)::numeric, 1) AS pct_change
+      FROM baseline b
+      JOIN current_price cp ON cp.card_id = b.card_id
+      WHERE b.price >= 2.0
+        AND cp.set_code IS NOT NULL
+        AND cp.price != b.price
     )
-    SELECT
-      p.set_code,
-      p.set_name,
-      MIN(p.released_at)::text AS released_at,
-      COUNT(DISTINCT p.card_id)::int AS unique_cards,
-      COUNT(DISTINCT cp.card_id)::int AS in_stock_cards,
-      SUM(cp.min_price)::text AS total_value
-    FROM printings p
-    LEFT JOIN card_prices cp ON cp.set_code = p.set_code AND cp.card_id = p.card_id
-    WHERE p.is_foil = false
-    GROUP BY p.set_code, p.set_name
-    HAVING COUNT(DISTINCT p.card_id) > 20
-      AND COUNT(DISTINCT cp.card_id) > 5
-    ORDER BY MIN(p.released_at) DESC
-    LIMIT 50
+    (
+      SELECT m.card_id, m.set_code, s.set_name, c.name, c.slug,
+             (SELECT p2.image_uri FROM printings p2
+              WHERE p2.card_id = m.card_id AND p2.image_uri IS NOT NULL AND p2.is_foil = false
+              ORDER BY p2.released_at DESC LIMIT 1) AS image_uri,
+             m.start_price::text, m.current_price::text, m.pct_change::text,
+             'up' AS direction
+      FROM movers m
+      JOIN cards c ON c.id = m.card_id
+      JOIN sets s ON s.set_code = m.set_code
+      WHERE m.pct_change > 0
+      ORDER BY m.pct_change DESC LIMIT 3
+    )
+    UNION ALL
+    (
+      SELECT m.card_id, m.set_code, s.set_name, c.name, c.slug,
+             (SELECT p2.image_uri FROM printings p2
+              WHERE p2.card_id = m.card_id AND p2.image_uri IS NOT NULL AND p2.is_foil = false
+              ORDER BY p2.released_at DESC LIMIT 1) AS image_uri,
+             m.start_price::text, m.current_price::text, m.pct_change::text,
+             'down' AS direction
+      FROM movers m
+      JOIN cards c ON c.id = m.card_id
+      JOIN sets s ON s.set_code = m.set_code
+      WHERE m.pct_change < 0
+      ORDER BY m.pct_change ASC LIMIT 3
+    )
   `;
 }
 
@@ -308,22 +402,24 @@ export type SetMetadata = {
   common_count: number;
 };
 
-/** Header stats for a single set page. */
+/** Header stats for a single set page. Basic lands excluded. */
 export async function getSetMetadata(setCode: string): Promise<SetMetadata | null> {
   const rows = await sql<SetMetadata[]>`
     SELECT
-      set_code,
-      set_name,
-      MIN(released_at)::text AS released_at,
-      COUNT(DISTINCT card_id)::int AS unique_cards,
+      p.set_code,
+      p.set_name,
+      MIN(p.released_at)::text AS released_at,
+      COUNT(DISTINCT p.card_id)::int AS unique_cards,
       COUNT(*)::int AS total_printings,
-      COUNT(*) FILTER (WHERE rarity = 'mythic' AND is_foil = false)::int AS mythic_count,
-      COUNT(*) FILTER (WHERE rarity = 'rare' AND is_foil = false)::int AS rare_count,
-      COUNT(*) FILTER (WHERE rarity = 'uncommon' AND is_foil = false)::int AS uncommon_count,
-      COUNT(*) FILTER (WHERE rarity = 'common' AND is_foil = false)::int AS common_count
-    FROM printings
-    WHERE set_code = ${setCode}
-    GROUP BY set_code, set_name
+      COUNT(*) FILTER (WHERE p.rarity = 'mythic' AND p.is_foil = false)::int AS mythic_count,
+      COUNT(*) FILTER (WHERE p.rarity = 'rare' AND p.is_foil = false)::int AS rare_count,
+      COUNT(*) FILTER (WHERE p.rarity = 'uncommon' AND p.is_foil = false)::int AS uncommon_count,
+      COUNT(*) FILTER (WHERE p.rarity = 'common' AND p.is_foil = false)::int AS common_count
+    FROM printings p
+    JOIN cards c ON c.id = p.card_id
+    WHERE p.set_code = ${setCode}
+      AND c.type_line NOT ILIKE 'Basic Land%'
+    GROUP BY p.set_code, p.set_name
   `;
   return rows[0] ?? null;
 }
@@ -334,8 +430,8 @@ export type SetPriceTimelinePoint = {
   card_count: number;
 };
 
-/** Daily total set value (sum of cheapest non-foil price per unique card). */
-export async function getSetPriceTimeline(setCode: string): Promise<SetPriceTimelinePoint[]> {
+/** Daily total set value (sum of cheapest non-foil price per unique card). Basic lands excluded. */
+export async function getSetPriceTimeline(setCodes: string[]): Promise<SetPriceTimelinePoint[]> {
   return sql<SetPriceTimelinePoint[]>`
     WITH daily_card_prices AS (
       SELECT
@@ -344,9 +440,11 @@ export async function getSetPriceTimeline(setCode: string): Promise<SetPriceTime
         MIN(ph.price_aud::numeric) AS min_price
       FROM price_history ph
       JOIN printings p ON p.id = ph.printing_id
-      WHERE p.set_code = ${setCode}
+      JOIN cards c ON c.id = p.card_id
+      WHERE p.set_code = ANY(${setCodes})
         AND ph.price_type = 'sell'
         AND p.is_foil = false
+        AND c.type_line NOT ILIKE 'Basic Land%'
       GROUP BY ph.recorded_at, p.card_id
     )
     SELECT
@@ -372,9 +470,9 @@ export type SetCardPerf = {
 
 /**
  * Per-card price performance: first recorded price vs current in-stock price.
- * Ordered by pct_change DESC (biggest gainers first).
+ * Ordered by pct_change DESC (biggest gainers first). Basic lands excluded.
  */
-export async function getSetCardPerformance(setCode: string): Promise<SetCardPerf[]> {
+export async function getSetCardPerformance(setCodes: string[]): Promise<SetCardPerf[]> {
   return sql<SetCardPerf[]>`
     WITH first_seen AS (
       SELECT
@@ -382,9 +480,11 @@ export async function getSetCardPerformance(setCode: string): Promise<SetCardPer
         MIN(ph.recorded_at) AS first_date
       FROM price_history ph
       JOIN printings p ON p.id = ph.printing_id
-      WHERE p.set_code = ${setCode}
+      JOIN cards c ON c.id = p.card_id
+      WHERE p.set_code = ANY(${setCodes})
         AND ph.price_type = 'sell'
         AND p.is_foil = false
+        AND c.type_line NOT ILIKE 'Basic Land%'
       GROUP BY p.card_id
     ),
     first_price AS (
@@ -393,7 +493,7 @@ export async function getSetCardPerformance(setCode: string): Promise<SetCardPer
         MIN(ph.price_aud::numeric) AS price
       FROM first_seen fs
       JOIN printings p ON p.card_id = fs.card_id
-        AND p.set_code = ${setCode}
+        AND p.set_code = ANY(${setCodes})
         AND p.is_foil = false
       JOIN price_history ph ON ph.printing_id = p.id
         AND ph.recorded_at = fs.first_date
@@ -406,20 +506,24 @@ export async function getSetCardPerformance(setCode: string): Promise<SetCardPer
         MIN(sp.price_aud::numeric) AS price
       FROM store_prices sp
       JOIN printings p ON p.id = sp.printing_id
-      WHERE p.set_code = ${setCode}
+      JOIN cards c ON c.id = p.card_id
+      WHERE p.set_code = ANY(${setCodes})
         AND sp.price_type = 'sell'
         AND sp.in_stock = true
         AND p.is_foil = false
+        AND c.type_line NOT ILIKE 'Basic Land%'
       GROUP BY p.card_id
     ),
     printing_info AS (
-      SELECT DISTINCT ON (card_id)
-        card_id,
-        rarity,
-        image_uri
-      FROM printings
-      WHERE set_code = ${setCode} AND is_foil = false
-      ORDER BY card_id, released_at ASC
+      SELECT DISTINCT ON (p.card_id)
+        p.card_id,
+        p.rarity,
+        p.image_uri
+      FROM printings p
+      JOIN cards c ON c.id = p.card_id
+      WHERE p.set_code = ANY(${setCodes}) AND p.is_foil = false
+        AND c.type_line NOT ILIKE 'Basic Land%'
+      ORDER BY p.card_id, p.released_at ASC
     )
     SELECT
       c.id AS card_id,
@@ -450,8 +554,8 @@ export type SetRarityBreakdown = {
   total_value: string | null;
 };
 
-/** Value distribution by rarity for in-stock non-foil cards. */
-export async function getSetRarityBreakdown(setCode: string): Promise<SetRarityBreakdown[]> {
+/** Value distribution by rarity for in-stock non-foil cards. Basic lands excluded. */
+export async function getSetRarityBreakdown(setCodes: string[]): Promise<SetRarityBreakdown[]> {
   return sql<SetRarityBreakdown[]>`
     WITH card_prices AS (
       SELECT
@@ -459,11 +563,13 @@ export async function getSetRarityBreakdown(setCode: string): Promise<SetRarityB
         p.rarity,
         MIN(sp.price_aud::numeric) AS min_price
       FROM printings p
+      JOIN cards c ON c.id = p.card_id
       JOIN store_prices sp ON sp.printing_id = p.id
-      WHERE p.set_code = ${setCode}
+      WHERE p.set_code = ANY(${setCodes})
         AND p.is_foil = false
         AND sp.in_stock = true
         AND sp.price_type = 'sell'
+        AND c.type_line NOT ILIKE 'Basic Land%'
       GROUP BY p.card_id, p.rarity
     )
     SELECT
@@ -509,6 +615,201 @@ export async function getSetStoreComparison(setCode: string): Promise<SetStoreCo
     GROUP BY s.id, s.name
     HAVING COUNT(sp.id) FILTER (WHERE sp.in_stock = true) > 0
     ORDER BY AVG(sp.price_aud::numeric) FILTER (WHERE sp.in_stock = true) ASC NULLS LAST
+  `;
+}
+
+export type SetReprintCard = {
+  card_id: string;
+  name: string;
+  slug: string | null;
+  rarity: string;
+  image_uri: string | null;
+  new_printing_price: string | null;
+  other_printing_price: string | null;
+  pct_diff: string | null;
+};
+
+// Set types considered "canonical" for reprint purposes — genuine MTG products
+// where a card appearing means it was truly reprinted, not just a same-release
+// variant (Secret Lair, promo drop, bonus sheet).
+const CANONICAL_SET_TYPES = [
+  "expansion", "core", "masters", "draft_innovation", "commander",
+  "planechase", "archenemy", "duel_deck", "from_the_vault", "spellbook",
+];
+
+/**
+ * Cards in this set that are genuine reprints — previously appeared in a
+ * canonical product type (expansion, core, masters, etc.) and NOT in a
+ * child/sibling release of this same set (Commander decks, promo drops,
+ * Secret Lairs sharing this set's parent).
+ *
+ * Compares this printing's price against the cheapest other qualifying printing.
+ */
+export async function getSetReprintCards(setCode: string): Promise<SetReprintCard[]> {
+  return sql<SetReprintCard[]>`
+    WITH this_set_printing AS (
+      SELECT DISTINCT ON (p.card_id)
+        p.card_id, p.id AS printing_id, p.rarity, p.image_uri
+      FROM printings p
+      JOIN cards c ON c.id = p.card_id
+      WHERE p.set_code = ${setCode} AND p.is_foil = false
+        AND c.type_line NOT ILIKE 'Basic Land%'
+      ORDER BY p.card_id, p.released_at ASC
+    ),
+    -- Cards that have a prior printing in a canonical set that is not a
+    -- child/sibling of this set's release family.
+    reprinted_cards AS (
+      SELECT tsp.card_id
+      FROM this_set_printing tsp
+      WHERE EXISTS (
+        SELECT 1
+        FROM printings p2
+        LEFT JOIN sets s ON s.set_code = p2.set_code
+        WHERE p2.card_id = tsp.card_id
+          AND p2.set_code != ${setCode}
+          AND p2.is_foil = false
+          -- Canonical set type, or unknown (NULL) during migration window
+          AND (s.set_type IS NULL OR s.set_type = ANY(${CANONICAL_SET_TYPES}))
+          -- Not a child of this set (same-release Commander decks, promos, etc.)
+          AND (s.parent_set_code IS NULL OR s.parent_set_code != ${setCode})
+      )
+    ),
+    new_printing_price AS (
+      SELECT tsp.card_id, MIN(sp.price_aud::numeric) AS price
+      FROM this_set_printing tsp
+      JOIN reprinted_cards rc ON rc.card_id = tsp.card_id
+      JOIN store_prices sp ON sp.printing_id = tsp.printing_id
+      WHERE sp.in_stock = true AND sp.price_type = 'sell'
+      GROUP BY tsp.card_id
+    ),
+    other_printing_price AS (
+      SELECT p.card_id, MIN(sp.price_aud::numeric) AS price
+      FROM printings p
+      JOIN reprinted_cards rc ON rc.card_id = p.card_id
+      LEFT JOIN sets s ON s.set_code = p.set_code
+      JOIN store_prices sp ON sp.printing_id = p.id
+      WHERE p.set_code != ${setCode}
+        AND p.is_foil = false
+        AND (s.set_type IS NULL OR s.set_type = ANY(${CANONICAL_SET_TYPES}))
+        AND (s.parent_set_code IS NULL OR s.parent_set_code != ${setCode})
+        AND sp.in_stock = true
+        AND sp.price_type = 'sell'
+      GROUP BY p.card_id
+    )
+    SELECT
+      c.id AS card_id,
+      c.name,
+      c.slug,
+      tsp.rarity,
+      tsp.image_uri,
+      npp.price::text AS new_printing_price,
+      opp.price::text AS other_printing_price,
+      CASE
+        WHEN opp.price > 0
+        THEN ROUND(((npp.price - opp.price) / opp.price * 100)::numeric, 1)::text
+        ELSE NULL
+      END AS pct_diff
+    FROM new_printing_price npp
+    JOIN other_printing_price opp ON opp.card_id = npp.card_id
+    JOIN cards c ON c.id = npp.card_id
+    JOIN this_set_printing tsp ON tsp.card_id = npp.card_id
+    ORDER BY ABS(npp.price - opp.price) DESC NULLS LAST
+    LIMIT 20
+  `;
+}
+
+export type SymbioticMover = {
+  card_id: string;
+  name: string;
+  slug: string | null;
+  image_uri: string | null;
+  first_price: string;
+  current_price: string;
+  pct_change: string;
+};
+
+/**
+ * Cards NOT in this set whose price increased ≥15% since the set's release date.
+ * Only meaningful for recently released sets — call only when released_at is within 90 days.
+ */
+export async function getSymbioticMovers(setCode: string, releasedAt: string): Promise<SymbioticMover[]> {
+  return sql<SymbioticMover[]>`
+    WITH set_card_ids AS (
+      SELECT DISTINCT card_id FROM printings WHERE set_code = ${setCode}
+    ),
+    -- Baseline: prefer first price on or after set release; fall back to oldest price
+    -- within a 30-day pre-release window. Scanning only the 30-day pre-release window
+    -- keeps query time reasonable (hits 1–2 partitions, not all history).
+    first_recorded AS (
+      SELECT
+        p.card_id,
+        COALESCE(
+          MIN(ph.recorded_at) FILTER (WHERE ph.recorded_at >= ${releasedAt}::date),
+          MIN(ph.recorded_at)
+        ) AS first_date
+      FROM price_history ph
+      JOIN printings p ON p.id = ph.printing_id
+      WHERE p.card_id NOT IN (SELECT card_id FROM set_card_ids)
+        AND p.is_foil = false
+        AND ph.price_type = 'sell'
+        AND ph.recorded_at >= ${releasedAt}::date - INTERVAL '30 days'
+      GROUP BY p.card_id
+    ),
+    first_price AS (
+      SELECT fr.card_id, MIN(ph.price_aud::numeric) AS price
+      FROM first_recorded fr
+      JOIN printings p ON p.card_id = fr.card_id AND p.is_foil = false
+      JOIN price_history ph ON ph.printing_id = p.id
+        AND ph.recorded_at = fr.first_date
+        AND ph.price_type = 'sell'
+      GROUP BY fr.card_id
+    ),
+    current_price AS (
+      SELECT p.card_id, MIN(sp.price_aud::numeric) AS price
+      FROM store_prices sp
+      JOIN printings p ON p.id = sp.printing_id
+      WHERE p.card_id NOT IN (SELECT card_id FROM set_card_ids)
+        AND p.is_foil = false
+        AND sp.in_stock = true
+        AND sp.price_type = 'sell'
+      GROUP BY p.card_id
+    )
+    SELECT
+      c.id AS card_id,
+      c.name,
+      c.slug,
+      (
+        SELECT p2.image_uri FROM printings p2
+        WHERE p2.card_id = c.id AND p2.image_uri IS NOT NULL AND p2.is_foil = false
+        ORDER BY p2.released_at DESC LIMIT 1
+      ) AS image_uri,
+      fp.price::text AS first_price,
+      cp.price::text AS current_price,
+      ROUND(((cp.price - fp.price) / fp.price * 100)::numeric, 1)::text AS pct_change
+    FROM first_price fp
+    JOIN current_price cp ON cp.card_id = fp.card_id
+    JOIN cards c ON c.id = fp.card_id
+    WHERE fp.price >= 1.0
+      AND cp.price > fp.price
+      AND (cp.price - fp.price) / fp.price >= 0.15
+    ORDER BY (cp.price - fp.price) / fp.price DESC
+    LIMIT 15
+  `;
+}
+
+export type ChildSet = {
+  set_code: string;
+  set_name: string;
+  set_type: string | null;
+};
+
+/** Child sets of the given set code (e.g. Commander decks, promo sets, bonus sheets). */
+export async function getChildSets(setCode: string): Promise<ChildSet[]> {
+  return sql<ChildSet[]>`
+    SELECT set_code, set_name, set_type
+    FROM sets
+    WHERE parent_set_code = ${setCode}
+    ORDER BY released_at ASC, set_name ASC
   `;
 }
 

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -7,6 +7,12 @@ export function fmtAUD(n: number): string {
   return `$${n.toFixed(2)}`;
 }
 
-export function cardHref(cardSlug: string | null | undefined, cardId: string): string {
-  return `/cards/${cardSlug ?? cardId}`;
+export function cardHref(
+  cardSlug: string | null | undefined,
+  cardId: string,
+  fromSet?: { code: string; name: string },
+): string {
+  const base = `/cards/${cardSlug ?? cardId}`;
+  if (!fromSet) return base;
+  return `${base}?from=${fromSet.code}&fromName=${encodeURIComponent(fromSet.name)}`;
 }

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,6 +2,7 @@ services:
   db:
     image: postgres:16-alpine
     restart: always
+    shm_size: 256mb
     logging:
       driver: json-file
       options:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ services:
   db:
     image: postgres:16-alpine
     restart: unless-stopped
+    shm_size: 256mb
     environment:
       POSTGRES_DB: mtg_tracker
       POSTGRES_USER: mtg

--- a/docs/prod-release.md
+++ b/docs/prod-release.md
@@ -1,0 +1,185 @@
+# Scrymarket — Production Release Guide
+
+## Pre-release checklist
+
+- [ ] Branch is merged to `main`
+- [ ] `pnpm --filter @mtg-au/web build` passes locally (no type errors)
+- [ ] Any new migrations were generated with `db:generate` (NOT hand-written) — hand-written SQL files are silently skipped by `drizzle-kit migrate` because they won't appear in `drizzle/meta/_journal.json`
+- [ ] `drizzle/meta/_journal.json` entry count matches the number of `.sql` files in `drizzle/`: `ls apps/scraper/drizzle/*.sql | wc -l` should equal the number of `entries` in the journal
+- [ ] `.env.example` updated if new env vars were added
+- [ ] `docker-quick-ref.md` updated if new manual commands are needed
+
+---
+
+## Standard release (code changes only, no migration)
+
+```bash
+cd /opt/mtg-au-tracker
+
+# 1. Pull latest
+git pull
+
+# 2. Rebuild changed services
+docker compose -f docker-compose.prod.yml build web scraper
+
+# 3. Restart
+docker compose -f docker-compose.prod.yml up -d
+
+# 4. Verify
+docker compose -f docker-compose.prod.yml logs web --tail=50
+docker compose -f docker-compose.prod.yml logs scraper --tail=50
+```
+
+---
+
+## Release with a DB migration
+
+Run the migration **before** restarting services. A running web container will
+continue serving the old schema while the migration applies cleanly.
+
+```bash
+cd /opt/mtg-au-tracker
+
+# 1. Pull latest
+git pull
+
+# 2. Apply migration (safe to run against live DB)
+docker compose -f docker-compose.prod.yml run --rm scraper \
+  pnpm --filter @mtg-au/scraper db:migrate
+
+# 3. Confirm migration applied
+docker compose -f docker-compose.prod.yml exec db \
+  psql -U mtg -d mtg_tracker -c \
+  "SELECT version, created_at FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"
+
+# 4. Rebuild and restart
+docker compose -f docker-compose.prod.yml build web scraper
+docker compose -f docker-compose.prod.yml up -d
+
+# 5. Verify services are healthy
+docker compose -f docker-compose.prod.yml ps
+docker compose -f docker-compose.prod.yml logs web --tail=50
+```
+
+---
+
+## Release requiring a Scryfall re-import
+
+Some changes need fresh Scryfall data to take effect (e.g. new fields on the
+`sets` table). Run the import after services are up.
+
+```bash
+# Trigger a Scryfall import manually (runs in foreground, ~10-15 min)
+docker compose -f docker-compose.prod.yml run --rm scraper \
+  pnpm --filter @mtg-au/scraper import:scryfall
+
+# Verify the import populated expected data
+docker compose -f docker-compose.prod.yml exec db \
+  psql -U mtg -d mtg_tracker -c \
+  "SELECT COUNT(*) AS cards FROM cards;
+   SELECT COUNT(*) AS printings FROM printings;
+   SELECT COUNT(*) AS sets FROM sets;
+   SELECT set_type, COUNT(*) FROM sets GROUP BY set_type ORDER BY 2 DESC LIMIT 10;"
+```
+
+Expected: ~32k cards, ~141k printings, ~700+ sets with `set_type` populated.
+
+---
+
+## Rollback
+
+### Code-only rollback
+
+```bash
+git revert HEAD   # or: git checkout <previous-commit>
+docker compose -f docker-compose.prod.yml build web scraper
+docker compose -f docker-compose.prod.yml up -d
+```
+
+### Migration rollback
+
+Drizzle does not generate automatic down migrations. To roll back a schema
+change you must write the inverse SQL manually and run it via psql:
+
+```bash
+docker compose -f docker-compose.prod.yml exec db psql -U mtg -d mtg_tracker
+```
+
+Then execute the inverse DDL (e.g. `DROP TABLE sets;` to undo the sets table migration).
+After reverting the schema, also revert the code and redeploy.
+
+> **Before any migration:** take a DB backup.
+> ```bash
+> docker compose -f docker-compose.prod.yml exec db \
+>   pg_dump -U mtg mtg_tracker > mtg_tracker_backup_$(date +%Y%m%d_%H%M).sql
+> ```
+
+---
+
+## Post-deploy smoke tests
+
+```bash
+# Services are up
+docker compose -f docker-compose.prod.yml ps
+
+# Web is responding
+curl -s -o /dev/null -w "%{http_code}" https://scrymarket.com.au
+# Expected: 200
+
+# DB has data
+docker compose -f docker-compose.prod.yml exec db \
+  psql -U mtg -d mtg_tracker -c \
+  "SELECT COUNT(*) FROM store_prices WHERE in_stock = true;"
+# Expected: > 0
+
+# No error spikes in logs
+docker compose -f docker-compose.prod.yml logs web --since 5m | grep -i error
+docker compose -f docker-compose.prod.yml logs scraper --since 5m | grep -i error
+```
+
+---
+
+## Specific releases
+
+### set_value_aud column (migration 0009)
+
+This adds `set_value_aud` to the `sets` table. The column is NULL until the first store scrape runs after migration. The `/sets` listing shows "—" until then, which is fine.
+
+1. Pull and migrate (standard release steps)
+2. Rebuild and restart — no Scryfall re-import needed
+3. Trigger a manual store scrape to populate values immediately:
+   ```bash
+   docker compose -f docker-compose.prod.yml run --rm scraper \
+     pnpm --filter @mtg-au/scraper scrape:stores
+   ```
+4. Verify:
+   ```bash
+   docker compose -f docker-compose.prod.yml exec db \
+     psql -U mtg -d mtg_tracker -c \
+     "SELECT set_code, set_name, set_value_aud FROM sets
+      WHERE parent_set_code IS NULL AND set_value_aud IS NOT NULL
+      ORDER BY released_at DESC LIMIT 10;"
+   ```
+
+---
+
+### sets table + Scryfall import pipeline (migration 0008)
+
+This release adds the `sets` table. `set_type` and `parent_set_code` will be
+`NULL` until the first Scryfall import runs — the app handles this gracefully.
+
+1. Pull and migrate (steps above)
+2. Rebuild and restart
+3. Run Scryfall import manually to populate `set_type` + `parent_set_code`
+4. Verify:
+
+```bash
+# Parent/child relationships populated
+docker compose -f docker-compose.prod.yml exec db \
+  psql -U mtg -d mtg_tracker -c \
+  "SELECT set_code, set_name, parent_set_code
+   FROM sets WHERE parent_set_code IS NOT NULL LIMIT 10;"
+
+# /sets listing excludes promos and tokens
+# Visit /sets in browser — no "Promo Pack" or token-only sets should appear
+```


### PR DESCRIPTION
## Summary
This PR adds a comprehensive set-level price tracking feature to Scrymarket, allowing users to explore Magic: The Gathering set releases and analyze price movements across Australian stores. The implementation includes set listing, detailed set pages with price history charts, card performance tracking, and store comparison data.

## Key Changes

### Database Layer (`lib/db.ts`)
- Added `getSetList()` to fetch all tracked sets with summary statistics (unique cards, in-stock count, total value)
- Added `getSetMetadata()` for set header information (rarity distribution, card counts)
- Added `getSetPriceTimeline()` to retrieve daily total set values for price history visualization
- Added `getSetCardPerformance()` to compute per-card price changes from first recorded price to current
- Added `getSetRarityBreakdown()` for value distribution analysis by rarity
- Added `getSetStoreComparison()` for store coverage and pricing comparison

### Pages & Routes
- **`/sets`** - Set listing page showing all tracked sets with quick stats (value, coverage, release date)
- **`/sets/[setCode]`** - Detailed set page with full analytics dashboard
- **`/sets/[setCode]/opengraph-image.tsx`** - Dynamic OG image generation for social sharing with set stats

### Components
- **`SetHero`** - Header section with set metadata, current value, and overall price change
- **`CrashCurveChart`** - Area chart showing total set value over time with insights (peak value, savings from waiting)
- **`WinnersLosersBoard`** - Side-by-side display of top 8 gainers and losers with price bars
- **`RarityBreakdown`** - Bar chart and stat cards showing value distribution by rarity
- **`StoreComparison`** - Table comparing store coverage and average prices
- **`SetCardExplorer`** - Sortable, filterable table of all cards in the set with pagination
- **`SetDataStory`** - Container component orchestrating all analytics sections

### Features
- **Price history visualization** with daily timeline data and narrative insights
- **Card-level performance tracking** showing percentage changes and price movements
- **Rarity-based filtering and analysis** with visual indicators
- **Store comparison** showing which AU retailers stock the set and at what average price
- **Responsive design** with mobile-optimized layouts
- **Dynamic OG image generation** for rich social media previews
- **Sortable/filterable card explorer** with pagination (25 cards per page)

## Implementation Details
- All set queries use efficient CTEs and aggregations to minimize database load
- Price history is tracked daily, enabling smooth timeline visualization
- Card performance calculations handle null values gracefully (cards without price history)
- OG image generation fetches Scryfall set icons and renders custom layouts with Next.js ImageResponse
- Components use client-side React hooks for sorting, filtering, and pagination
- Revalidation set to 1 hour (3600s) for fresh data without constant regeneration

https://claude.ai/code/session_01EMCEBMPqNVjbqjjCN58G83