### PR TITLE
Extract variant utilities and enhance card variant display

### DIFF
--- a/apps/web/src/app/WantListContext.tsx
+++ b/apps/web/src/app/WantListContext.tsx
@@ -12,6 +12,9 @@ export interface WantListItem {
   setCode: string;
   rarity: string;
   isFoil: boolean;
+  finish?: "nonfoil" | "foil" | "etched";   // optional: older localStorage items won't have this
+  borderColor?: string | null;               // for variant badge display
+  frameEffects?: string[];                   // for variant badge display
   storeId: string;
   storeName: string;
   priceAud: number;

--- a/apps/web/src/app/api/cards/store-printings/route.ts
+++ b/apps/web/src/app/api/cards/store-printings/route.ts
@@ -15,6 +15,9 @@ export async function GET(req: NextRequest) {
     collector_number: string;
     rarity: string;
     is_foil: boolean;
+    finish: string;
+    border_color: string | null;
+    frame_effects: string[];
     image_uri: string | null;
     price_aud: string;
     shipping_aud: string | null;
@@ -30,6 +33,9 @@ export async function GET(req: NextRequest) {
       p.collector_number,
       p.rarity,
       p.is_foil,
+      p.finish,
+      p.border_color,
+      p.frame_effects,
       p.image_uri,
       sp.price_aud,
       sp.shipping_aud,
@@ -54,6 +60,9 @@ export async function GET(req: NextRequest) {
       collectorNumber: r.collector_number,
       rarity: r.rarity,
       isFoil: r.is_foil,
+      finish: r.finish ?? (r.is_foil ? "foil" : "nonfoil"),
+      borderColor: r.border_color ?? null,
+      frameEffects: r.frame_effects ?? [],
       imageUri: r.image_uri,
       priceAud: parseFloat(r.price_aud),
       shippingAud: r.shipping_aud ? parseFloat(r.shipping_aud) : null,

--- a/apps/web/src/app/api/cards/store-printings/route.ts
+++ b/apps/web/src/app/api/cards/store-printings/route.ts
@@ -72,7 +72,7 @@ export async function GET(req: NextRequest) {
       collectorNumber: r.collector_number,
       rarity: r.rarity,
       isFoil: r.is_foil,
-      finish: r.finish ?? (r.is_foil ? "foil" : "nonfoil"),
+      finish: (r.finish ?? (r.is_foil ? "foil" : "nonfoil")) as "nonfoil" | "foil" | "etched",
       borderColor: r.border_color ?? null,
       frameEffects: r.frame_effects ?? [],
       imageUri: r.image_uri,

--- a/apps/web/src/app/api/optimize/algorithm.ts
+++ b/apps/web/src/app/api/optimize/algorithm.ts
@@ -20,6 +20,8 @@ export type Listing = {
   rarity: string;
   isFoil: boolean;
   finish: "nonfoil" | "foil" | "etched";
+  borderColor: string | null;
+  frameEffects: string[];
   imageUri: string | null;
 };
 

--- a/apps/web/src/app/api/optimize/route.test.ts
+++ b/apps/web/src/app/api/optimize/route.test.ts
@@ -1,23 +1,8 @@
 import { describe, it, expect } from "vitest";
 import { branchAndBound, evaluateSubset } from "./algorithm";
-import type { OptimizeItem } from "./algorithm";
+import type { OptimizeItem, Listing } from "./algorithm";
 
 // ── Test fixtures ─────────────────────────────────────────────────────────────
-
-type Listing = {
-  printingId: string;
-  storeId: string;
-  storeName: string;
-  priceAud: number;
-  shippingAud: number | null;
-  condition: string | null;
-  url: string | null;
-  setName: string;
-  setCode: string;
-  rarity: string;
-  isFoil: boolean;
-  imageUri: string | null;
-};
 
 function listing(storeId: string, priceAud: number, shippingAud: number | null = null): Listing {
   return {
@@ -32,6 +17,9 @@ function listing(storeId: string, priceAud: number, shippingAud: number | null =
     setCode: "tst",
     rarity: "common",
     isFoil: false,
+    finish: "nonfoil",
+    borderColor: null,
+    frameEffects: [],
     imageUri: null,
   };
 }

--- a/apps/web/src/app/api/optimize/route.ts
+++ b/apps/web/src/app/api/optimize/route.ts
@@ -25,6 +25,7 @@ type Listing = {
   setCode: string;
   rarity: string;
   isFoil: boolean;
+  finish: "nonfoil" | "foil" | "etched";
   imageUri: string | null;
 };
 
@@ -42,6 +43,7 @@ export type OptimizeAssignment = {
   setCode: string;
   rarity: string;
   isFoil: boolean;
+  finish: "nonfoil" | "foil" | "etched";
   imageUri: string | null;
 };
 
@@ -231,6 +233,7 @@ export async function POST(request: Request) {
     set_code: string;
     rarity: string;
     is_foil: boolean;
+    finish: string;
     image_uri: string | null;
   }[]>`
     SELECT
@@ -246,6 +249,7 @@ export async function POST(request: Request) {
       p.set_code,
       p.rarity,
       p.is_foil,
+      p.finish,
       p.image_uri
     FROM printings p
     JOIN store_prices sp ON sp.printing_id = p.id
@@ -283,6 +287,7 @@ export async function POST(request: Request) {
       setCode: row.set_code,
       rarity: row.rarity,
       isFoil: row.is_foil,
+      finish: (row.finish as "nonfoil" | "foil" | "etched") ?? (row.is_foil ? "foil" : "nonfoil"),
       imageUri: row.image_uri,
     };
     byCard.get(row.card_id)!.push(listing);
@@ -379,6 +384,7 @@ export async function POST(request: Request) {
       setCode: listing.setCode,
       rarity: listing.rarity,
       isFoil: listing.isFoil,
+      finish: listing.finish,
       imageUri: listing.imageUri,
     };
   });

--- a/apps/web/src/app/api/optimize/route.ts
+++ b/apps/web/src/app/api/optimize/route.ts
@@ -28,6 +28,8 @@ export type OptimizeAssignment = {
   rarity: string;
   isFoil: boolean;
   finish: "nonfoil" | "foil" | "etched";
+  borderColor: string | null;
+  frameEffects: string[];
   imageUri: string | null;
 };
 
@@ -96,6 +98,8 @@ export async function POST(request: NextRequest) {
     rarity: string;
     is_foil: boolean;
     finish: string;
+    border_color: string | null;
+    frame_effects: string[];
     image_uri: string | null;
   }[]>`
     SELECT
@@ -112,6 +116,8 @@ export async function POST(request: NextRequest) {
       p.rarity,
       p.is_foil,
       p.finish,
+      p.border_color,
+      p.frame_effects,
       p.image_uri
     FROM printings p
     JOIN store_prices sp ON sp.printing_id = p.id
@@ -149,7 +155,9 @@ export async function POST(request: NextRequest) {
       setCode: row.set_code,
       rarity: row.rarity,
       isFoil: row.is_foil,
-      finish: (row.finish as "nonfoil" | "foil" | "etched") ?? (row.is_foil ? "foil" : "nonfoil"),
+      finish: (row.finish ?? (row.is_foil ? "foil" : "nonfoil")) as "nonfoil" | "foil" | "etched",
+      borderColor: row.border_color ?? null,
+      frameEffects: row.frame_effects ?? [],
       imageUri: row.image_uri,
     };
     byCard.get(row.card_id)!.push(listing);
@@ -247,6 +255,8 @@ export async function POST(request: NextRequest) {
       rarity: listing.rarity,
       isFoil: listing.isFoil,
       finish: listing.finish,
+      borderColor: listing.borderColor,
+      frameEffects: listing.frameEffects,
       imageUri: listing.imageUri,
     };
   });

--- a/apps/web/src/app/cards/[slug]/PricesTable.tsx
+++ b/apps/web/src/app/cards/[slug]/PricesTable.tsx
@@ -7,9 +7,9 @@ import { fmtAUD } from "@/lib/utils";
 import { Dropdown, OptionItem } from "@/app/Dropdown";
 import { SetSymbol } from "@/app/SetSymbol";
 import { BuyLink } from "@/app/BuyLink";
+import { getVariantTags, variantBadge, VARIANT_LABELS, VARIANT_ORDER, type VariantTag } from "@/lib/variant-utils";
 
 type SortBy = "price_asc" | "price_desc" | "total_asc" | "total_desc" | "newest" | "oldest";
-type VariantTag = "standard" | "foil" | "etched" | "borderless" | "borderless-foil" | "showcase" | "extendedart" | "fullart";
 
 const SORT_LABELS: Record<SortBy, string> = {
   price_asc: "Price: Low → High",
@@ -19,50 +19,6 @@ const SORT_LABELS: Record<SortBy, string> = {
   newest: "Newest Set First",
   oldest: "Oldest Set First",
 };
-
-const VARIANT_LABELS: Record<VariantTag, string> = {
-  standard: "Standard",
-  foil: "Foil",
-  etched: "Etched",
-  borderless: "Borderless",
-  "borderless-foil": "Borderless Foil",
-  showcase: "Showcase",
-  extendedart: "Extended Art",
-  fullart: "Full Art",
-};
-
-const VARIANT_ORDER: VariantTag[] = ["standard", "foil", "etched", "borderless", "borderless-foil", "showcase", "extendedart", "fullart"];
-
-function getVariantTags(p: PrintingWithPrices): Set<VariantTag> {
-  const tags = new Set<VariantTag>();
-  const isBorderless = p.borderColor === "borderless";
-  const isSpecialFrame =
-    p.frameEffects.includes("showcase") ||
-    p.frameEffects.includes("extendedart") ||
-    p.frameEffects.includes("fullart");
-
-  if (p.frameEffects.includes("showcase"))    tags.add("showcase");
-  if (p.frameEffects.includes("extendedart")) tags.add("extendedart");
-  if (p.frameEffects.includes("fullart"))     tags.add("fullart");
-  if (isBorderless && p.finish !== "nonfoil") tags.add("borderless-foil");
-  else if (isBorderless)                      tags.add("borderless");
-  if (p.finish === "etched")                  tags.add("etched");
-  if (p.finish === "foil" && !isBorderless && !isSpecialFrame) tags.add("foil");
-  if (p.finish === "nonfoil" && !isBorderless && !isSpecialFrame) tags.add("standard");
-  return tags;
-}
-
-function variantBadge(p: PrintingWithPrices): string | null {
-  const tags = getVariantTags(p);
-  if (tags.has("borderless-foil")) return "Borderless Foil";
-  if (tags.has("borderless")) return "Borderless";
-  if (tags.has("etched")) return "Etched";
-  if (tags.has("showcase")) return p.finish !== "nonfoil" ? "Showcase Foil" : "Showcase";
-  if (tags.has("extendedart")) return p.finish !== "nonfoil" ? "Extended Art Foil" : "Extended Art";
-  if (tags.has("fullart")) return p.finish !== "nonfoil" ? "Full Art Foil" : "Full Art";
-  if (tags.has("foil")) return null; // shown via ✦ symbol instead
-  return null;
-}
 
 interface Row {
   printing: PrintingWithPrices;
@@ -117,6 +73,9 @@ function WantListButton({
             setCode: row.printing.setCode,
             rarity: row.printing.rarity,
             isFoil: row.printing.isFoil,
+            finish: row.printing.finish,
+            borderColor: row.printing.borderColor,
+            frameEffects: row.printing.frameEffects,
             storeId: row.storeId,
             storeName: row.storeName,
             priceAud: row.priceAud,

--- a/apps/web/src/app/want-list/WantListView.tsx
+++ b/apps/web/src/app/want-list/WantListView.tsx
@@ -82,7 +82,7 @@ function PrintingSelector({
     <div ref={ref} className="relative inline-block">
       <button
         onClick={() => setOpen(!open)}
-        title={`${item.setName}${item.finish === "etched" ? " (Etched)" : item.isFoil ? " (Foil)" : ""} — click to change printing or store`}
+        title={`${item.setName}${(() => { const v = variantBadge({ finish: item.finish ?? "nonfoil", borderColor: item.borderColor ?? null, frameEffects: item.frameEffects ?? [] }) ?? (item.finish === "foil" ? "Foil" : null); return v ? ` (${v})` : ""; })()} — click to change printing or store`}
         className="flex items-center gap-0.5 hover:opacity-70 transition-opacity"
       >
         <SetSymbol setCode={item.setCode} setName={item.setName} rarity={item.rarity} />
@@ -416,10 +416,10 @@ function OptimiseModal({
                               <span className="text-cream-dim/30">locked · {cur.storeName}</span>
                             ) : (
                               <>
-                                {cur.storeName}{printingChanged && <> · {cur.setName}{cur.finish && cur.finish !== "nonfoil" ? <> · {cur.finish === "etched" ? "Etched" : "Foil"}</> : ""}</>}
+                                {cur.storeName}{printingChanged && <> · {cur.setName}{(() => { const v = variantBadge({ finish: cur.finish ?? "nonfoil", borderColor: cur.borderColor ?? null, frameEffects: cur.frameEffects ?? [] }) ?? (cur.finish === "foil" ? "Foil" : null); return v ? <> · {v}</> : ""; })()}</>}
                                 <span className="mx-1">→</span>
                                 <span className="text-cream-dim/70">{a.storeName}</span>
-                                {printingChanged && <span className="text-cream-dim/70"> · {a.setName}{a.finish && a.finish !== "nonfoil" ? ` · ${a.finish === "etched" ? "Etched" : "Foil"}` : ""}</span>}
+                                {printingChanged && <span className="text-cream-dim/70"> · {a.setName}{(() => { const v = variantBadge({ finish: a.finish, borderColor: a.borderColor, frameEffects: a.frameEffects }) ?? (a.finish === "foil" ? "Foil" : null); return v ? ` · ${v}` : ""; })()}</span>}
                               </>
                             )}
                           </div>
@@ -658,6 +658,8 @@ export function WantListView() {
         rarity: a.rarity,
         isFoil: a.isFoil,
         finish: a.finish,
+        borderColor: a.borderColor,
+        frameEffects: a.frameEffects,
         imageUri: a.imageUri,
       });
     }

--- a/apps/web/src/app/want-list/WantListView.tsx
+++ b/apps/web/src/app/want-list/WantListView.tsx
@@ -10,6 +10,7 @@ import { BuyLink } from "@/app/BuyLink";
 import { ImportCards } from "./ImportCards";
 import type { OptimizeResult } from "@/app/api/optimize/route";
 import { cardHref } from "@/lib/utils";
+import { variantBadge } from "@/lib/variant-utils";
 
 // ── Printing selector ─────────────────────────────────────────────────────────
 
@@ -20,6 +21,9 @@ type StorePrinting = {
   collectorNumber: string;
   rarity: string;
   isFoil: boolean;
+  finish: string;
+  borderColor: string | null;
+  frameEffects: string[];
   imageUri: string | null;
   priceAud: number;
   shippingAud: number | null;
@@ -78,7 +82,7 @@ function PrintingSelector({
     <div ref={ref} className="relative inline-block">
       <button
         onClick={() => setOpen(!open)}
-        title={`${item.setName}${item.isFoil ? " (Foil)" : ""} — click to change printing or store`}
+        title={`${item.setName}${item.finish === "etched" ? " (Etched)" : item.isFoil ? " (Foil)" : ""} — click to change printing or store`}
         className="flex items-center gap-0.5 hover:opacity-70 transition-opacity"
       >
         <SetSymbol setCode={item.setCode} setName={item.setName} rarity={item.rarity} />
@@ -119,7 +123,13 @@ function PrintingSelector({
                   >
                     <SetSymbol setCode={p.setCode} setName={p.setName} rarity={p.rarity} />
                     <span className="flex-1 truncate">
-                      {p.setName} #{p.collectorNumber}{p.isFoil ? " ✦" : ""}
+                      {p.setName} #{p.collectorNumber}
+                      {(() => {
+                        const badge = variantBadge({ finish: p.finish, borderColor: p.borderColor, frameEffects: p.frameEffects });
+                        if (badge) return <span className="ml-1 text-accent/80">· {badge}</span>;
+                        if (p.isFoil) return <span className="ml-1 text-accent/80">✦</span>;
+                        return null;
+                      })()}
                     </span>
                     <span className="text-cream-dim/40 text-[10px] shrink-0">{p.storeName}</span>
                     <span className="text-price font-semibold whitespace-nowrap">{fmtAUD(p.priceAud)}</span>
@@ -406,10 +416,10 @@ function OptimiseModal({
                               <span className="text-cream-dim/30">locked · {cur.storeName}</span>
                             ) : (
                               <>
-                                {cur.storeName}{printingChanged && <> · {cur.setName}</>}
+                                {cur.storeName}{printingChanged && <> · {cur.setName}{cur.finish && cur.finish !== "nonfoil" ? <> · {cur.finish === "etched" ? "Etched" : "Foil"}</> : ""}</>}
                                 <span className="mx-1">→</span>
                                 <span className="text-cream-dim/70">{a.storeName}</span>
-                                {printingChanged && <span className="text-cream-dim/70"> · {a.setName}</span>}
+                                {printingChanged && <span className="text-cream-dim/70"> · {a.setName}{a.finish && a.finish !== "nonfoil" ? ` · ${a.finish === "etched" ? "Etched" : "Foil"}` : ""}</span>}
                               </>
                             )}
                           </div>
@@ -647,6 +657,7 @@ export function WantListView() {
         setCode: a.setCode,
         rarity: a.rarity,
         isFoil: a.isFoil,
+        finish: a.finish,
         imageUri: a.imageUri,
       });
     }
@@ -682,6 +693,9 @@ export function WantListView() {
       setCode: p.setCode,
       rarity: p.rarity,
       isFoil: p.isFoil,
+      finish: p.finish as "nonfoil" | "foil" | "etched",
+      borderColor: p.borderColor,
+      frameEffects: p.frameEffects,
       storeId: p.storeId,
       storeName: p.storeName,
       priceAud: p.priceAud,

--- a/apps/web/src/lib/variant-utils.ts
+++ b/apps/web/src/lib/variant-utils.ts
@@ -1,0 +1,61 @@
+export type VariantTag =
+  | "standard"
+  | "foil"
+  | "etched"
+  | "borderless"
+  | "borderless-foil"
+  | "showcase"
+  | "extendedart"
+  | "fullart";
+
+export const VARIANT_LABELS: Record<VariantTag, string> = {
+  standard:        "Standard",
+  foil:            "Foil",
+  etched:          "Etched",
+  borderless:      "Borderless",
+  "borderless-foil": "Borderless Foil",
+  showcase:        "Showcase",
+  extendedart:     "Extended Art",
+  fullart:         "Full Art",
+};
+
+export const VARIANT_ORDER: VariantTag[] = [
+  "standard", "foil", "etched", "borderless", "borderless-foil",
+  "showcase", "extendedart", "fullart",
+];
+
+type VariantSource = {
+  finish: string;
+  borderColor: string | null | undefined;
+  frameEffects: string[];
+};
+
+export function getVariantTags(p: VariantSource): Set<VariantTag> {
+  const tags = new Set<VariantTag>();
+  const isBorderless = p.borderColor === "borderless";
+  const isSpecialFrame =
+    p.frameEffects.includes("showcase") ||
+    p.frameEffects.includes("extendedart") ||
+    p.frameEffects.includes("fullart");
+
+  if (p.frameEffects.includes("showcase"))    tags.add("showcase");
+  if (p.frameEffects.includes("extendedart")) tags.add("extendedart");
+  if (p.frameEffects.includes("fullart"))     tags.add("fullart");
+  if (isBorderless && p.finish !== "nonfoil") tags.add("borderless-foil");
+  else if (isBorderless)                      tags.add("borderless");
+  if (p.finish === "etched")                  tags.add("etched");
+  if (p.finish === "foil" && !isBorderless && !isSpecialFrame)    tags.add("foil");
+  if (p.finish === "nonfoil" && !isBorderless && !isSpecialFrame) tags.add("standard");
+  return tags;
+}
+
+export function variantBadge(p: VariantSource): string | null {
+  const tags = getVariantTags(p);
+  if (tags.has("borderless-foil")) return "Borderless Foil";
+  if (tags.has("borderless"))      return "Borderless";
+  if (tags.has("etched"))          return "Etched";
+  if (tags.has("showcase"))        return p.finish !== "nonfoil" ? "Showcase Foil" : "Showcase";
+  if (tags.has("extendedart"))     return p.finish !== "nonfoil" ? "Extended Art Foil" : "Extended Art";
+  if (tags.has("fullart"))         return p.finish !== "nonfoil" ? "Full Art Foil" : "Full Art";
+  return null; // standard and foil shown via other UI cues
+}


### PR DESCRIPTION
## Summary
This PR extracts card variant logic into a reusable utility module and enhances the display of card variants (foil, etched, borderless, showcase, etc.) throughout the application. The changes improve code reusability and provide more detailed variant information in the want list UI.

## Key Changes

- **New module**: Created `apps/web/src/lib/variant-utils.ts` containing:
  - `VariantTag` type definition for all supported card variants
  - `VARIANT_LABELS` and `VARIANT_ORDER` constants for consistent variant naming and ordering
  - `getVariantTags()` function to extract variant tags from card properties (finish, borderColor, frameEffects)
  - `variantBadge()` function to generate display-friendly variant labels

- **PricesTable.tsx**: Removed duplicate variant logic and imported utilities from the new module

- **WantListView.tsx**: 
  - Enhanced variant display in the printing selector to show detailed variant badges (e.g., "Showcase Foil", "Extended Art") instead of just a foil indicator
  - Updated printing change descriptions in the optimize modal to include variant information
  - Added `finish`, `borderColor`, and `frameEffects` fields to `StorePrinting` type

- **API routes**: Updated `store-printings` and `optimize` routes to:
  - Query and return `finish`, `border_color`, and `frame_effects` from the database
  - Map these fields to the response objects with sensible defaults

- **WantListContext.tsx**: Extended `WantListItem` interface with optional `finish`, `borderColor`, and `frameEffects` fields for backward compatibility with existing localStorage data

## Implementation Details

- The variant detection logic intelligently handles combinations (e.g., borderless + foil = "Borderless Foil")
- Special frame effects (showcase, extended art, full art) take precedence in variant classification
- The `variantBadge()` function returns `null` for standard and foil variants as they're shown via other UI cues
- All changes maintain backward compatibility with existing data structures

https://claude.ai/code/session_01DTAXZ3JcMRFxoRP1BvFzmW