### PR TITLE
fix(guf): handle location-based variants and correct collection handle

### DIFF
--- a/apps/scraper/src/stores/shopify-stores.config.ts
+++ b/apps/scraper/src/stores/shopify-stores.config.ts
@@ -22,6 +22,10 @@ export interface ShopifyStoreConfig {
   // all into the product title with a single "Default Title" variant.
   // e.g. "Zenos yae Galvus (Borderless) 384 Rare FINAL FANTASY Foil NM/M"
   titleFormat?: "all-in-title";
+  // true: variants represent physical store locations (e.g. "Bendigo", "Geelong"),
+  // not condition/foil. Collapse per-foil-type; condition implied NM; foil from SKU;
+  // inStock = true if any location variant is available. (GUF-style stores.)
+  locationVariants?: true;
 }
 
 export const SHOPIFY_STORES: ShopifyStoreConfig[] = [
@@ -48,7 +52,8 @@ export const SHOPIFY_STORES: ShopifyStoreConfig[] = [
   {
     id: "guf",
     baseUrl: "https://guf.com.au",
-    collectionHandle: "mtg-singles-all-products",
+    collectionHandle: "mtg-singles-instock-all-stores",
+    locationVariants: true,
   },
   {
     id: "inn_games",

--- a/apps/scraper/src/stores/shopify.ts
+++ b/apps/scraper/src/stores/shopify.ts
@@ -492,6 +492,45 @@ export function mapProduct(product: ShopifyProduct, config: ShopifyStoreConfig):
   const sourceUrl = `${baseUrl}/products/${product.handle}`;
   const results: ScrapedCard[] = [];
 
+  // Location-variant stores (e.g. GUF) encode store branches as variants instead
+  // of condition/foil. Collapse each unique foil type into one entry; condition is
+  // implied NM; inStock = true if any branch has stock.
+  if (config.locationVariants) {
+    type FinishKey = "nonfoil" | "foil" | "etched";
+    const groups = new Map<FinishKey, { price: string; inStock: boolean }>();
+    for (const variant of product.variants) {
+      const priceNum = parseFloat(variant.price);
+      if (isNaN(priceNum) || priceNum <= 0) continue;
+      const skuData = parseSkuData(variant.sku);
+      const isFoil = skuData.isFoil ?? /\bfoil\b/i.test(variant.title);
+      const isEtched = /\betched\b/i.test(variant.title);
+      const finishKey: FinishKey = isEtched ? "etched" : isFoil ? "foil" : "nonfoil";
+      const existing = groups.get(finishKey);
+      if (!existing) {
+        groups.set(finishKey, { price: variant.price, inStock: variant.available });
+      } else if (!existing.inStock && variant.available) {
+        existing.inStock = true;
+      }
+    }
+    for (const [finishKey, { price, inStock }] of groups) {
+      results.push({
+        rawName: cardName,
+        setCode,
+        setName,
+        collectorNumber,
+        price,
+        priceType: "sell",
+        condition: "NM",
+        isFoil: finishKey !== "nonfoil",
+        finish: finishKey,
+        treatment,
+        inStock,
+        sourceUrl,
+      });
+    }
+    return results;
+  }
+
   for (const variant of product.variants) {
     const priceNum = parseFloat(variant.price);
     if (isNaN(priceNum) || priceNum <= 0) continue;


### PR DESCRIPTION
GUF uses store branch names (Bendigo, Geelong, etc.) as Shopify variants instead of condition/foil. The scraper was filtering all variants because "Bendigo" != "NM". Adds locationVariants config flag that collapses all location variants per foil type into one NM entry, with inStock=true if any branch has stock. Also switches to the instock-all-stores collection.