### PR TITLE
fix(elemental-arcade): correct collection handle to magic-the-gatheri…

### DIFF
--- a/apps/scraper/src/stores/shopify-stores.config.ts
+++ b/apps/scraper/src/stores/shopify-stores.config.ts
@@ -113,7 +113,7 @@ export const SHOPIFY_STORES: ShopifyStoreConfig[] = [
   {
     id: "elemental_arcade",
     baseUrl: "https://elementalarcade.com.au",
-    collectionHandle: "mtg-singles-all-products",
+    collectionHandle: "magic-the-gathering-tcg-singles",
   },
   {
     id: "ronin_games",


### PR DESCRIPTION
…ng-tcg-singles

mtg-singles-all-products returned 0 results; confirmed correct handle via products.json.