### PR TITLE
ci: build+push images to GHCR, switch prod deploy to pull-based

### DIFF
--- a/.github/workflows/deploy-images.yml
+++ b/.github/workflows/deploy-images.yml
@@ -1,0 +1,59 @@
+name: Build & push images
+
+# Builds the scraper + web images and pushes them to GHCR on every merge to main.
+# The server never builds — it pulls these images via scripts/deploy.sh.
+# Full typecheck/test already ran on the PR (ci.yml) before merge, so this workflow
+# only builds the already-green main.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build-push:
+    name: Build & push (${{ matrix.name }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: scraper
+            image: ghcr.io/luperr/scrymarket-scraper
+            dockerfile: docker/Dockerfile.scraper
+          - name: web
+            image: ghcr.io/luperr/scrymarket-web
+            dockerfile: docker/Dockerfile.web
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ matrix.image }}
+          tags: |
+            type=raw,value=latest
+            type=sha,prefix=main-
+          # main-<shortsha> is immutable — deploy.sh <tag> uses it to pin/rollback
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          platforms: linux/amd64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ The goal: a self-hosted, self-sustaining price tracker for AU MTG players to com
 | Scheduling | `node-cron` (pinned to `Australia/Sydney` timezone) |
 | Web app | Next.js 15 (App Router) |
 | Analytics | Umami (self-hosted, custom events) |
-| Deployment | Docker Compose on Proxmox LXC, public via Cloudflare tunnel |
+| Deployment | Images built+pushed to GHCR by GitHub Actions; server pulls via Docker Compose on Proxmox LXC, public via Cloudflare tunnel |
 
 ---
 
@@ -212,6 +212,28 @@ See `.env.example` for all variables. Key ones:
 | `USER_AGENT` | HTTP User-Agent for scraping | `Scrymarket/1.0` |
 | `AUD_USD_RATE` | Static USD→AUD rate | `0.65` |
 | `CLOUDFLARE_TUNNEL_TOKEN` | Token for `cloudflared` tunnel service | — |
+| `IMAGE_REGISTRY` | Registry+namespace for prod images (ECR-swap lever) | `ghcr.io/luperr` |
+| `IMAGE_TAG` | Which prod image to run; `main-<sha>` to pin/rollback | `latest` |
+
+---
+
+## Deployment
+
+Images are **built and pushed to GHCR by GitHub Actions** (`.github/workflows/deploy-images.yml`)
+on every merge to `main` — the server never builds. Deploying is a pull:
+
+```bash
+# On the server (repo checkout at /opt/mtg-au-tracker):
+./scripts/deploy.sh                 # deploy :latest
+./scripts/deploy.sh main-abc1234    # pin/rollback to a specific image tag
+```
+
+`deploy.sh` runs `git pull` (refreshes compose + migration SQL) → `docker compose pull` →
+`db:migrate` (before restart) → `up -d`. `docker-compose.prod.yml` references images via
+`${IMAGE_REGISTRY:-ghcr.io/luperr}/scrymarket-{web,scraper}:${IMAGE_TAG:-latest}`; the
+`build:` blocks remain only as an emergency fallback. This is deliberately AWS-ready: the
+image is the deploy artifact, migrations are a discrete command, and `IMAGE_REGISTRY` makes
+GHCR→ECR a config swap. Full runbook: `docs/prod-release.md`.
 
 ---
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -23,7 +23,8 @@ services:
       - backend
 
   scraper:
-    build:
+    image: ${IMAGE_REGISTRY:-ghcr.io/luperr}/scrymarket-scraper:${IMAGE_TAG:-latest}
+    build:                       # fallback only — normal deploys pull, never build
       context: .
       dockerfile: docker/Dockerfile.scraper
     user: "1002:1002"
@@ -62,7 +63,8 @@ services:
       - backend
 
   web:
-    build:
+    image: ${IMAGE_REGISTRY:-ghcr.io/luperr}/scrymarket-web:${IMAGE_TAG:-latest}
+    build:                       # fallback only — normal deploys pull, never build
       context: .
       dockerfile: docker/Dockerfile.web
     user: "1001:1001"

--- a/docs/prod-release.md
+++ b/docs/prod-release.md
@@ -11,21 +11,41 @@
 
 ---
 
+## How deploys work now
+
+Images are **built and pushed to GHCR by GitHub Actions** on every merge to `main`
+(`.github/workflows/deploy-images.yml`) — the server never builds. Deploying is a
+**pull**, driven by `scripts/deploy.sh`.
+
+Image references in `docker-compose.prod.yml` are registry-agnostic:
+
+| Var | Default | Purpose |
+|---|---|---|
+| `IMAGE_REGISTRY` | `ghcr.io/luperr` | Registry + namespace. Single lever for a future ECR swap. |
+| `IMAGE_TAG` | `latest` | Which image to run. Set to `main-<sha>` to pin or roll back. |
+
+Both are optional (inline defaults in the compose file); `deploy.sh` sets `IMAGE_TAG`
+for you from its first argument.
+
+**One-time GHCR access:** the `scrymarket-scraper` / `scrymarket-web` packages must be
+readable by the server. Simplest is to set both packages to **public** visibility in the
+repo's GitHub Packages settings (they're just compiled artifacts). If you keep them
+private, run once on the server:
+`echo <PAT-with-read:packages> | docker login ghcr.io -u luperr --password-stdin`.
+
+---
+
 ## Standard release (code changes only, no migration)
 
 ```bash
-cd /opt/mtg-au-tracker
+# On the server (repo checkout at /opt/mtg-au-tracker):
+./scripts/deploy.sh
+```
 
-# 1. Pull latest
-git pull
+That's it — `deploy.sh` runs `git pull` (to refresh the compose file + migration SQL),
+`docker compose pull web scraper`, `db:migrate`, then `up -d` and prints `ps`. Then:
 
-# 2. Rebuild changed services
-docker compose -f docker-compose.prod.yml build web scraper
-
-# 3. Restart
-docker compose -f docker-compose.prod.yml up -d
-
-# 4. Verify
+```bash
 docker compose -f docker-compose.prod.yml logs web --tail=50
 docker compose -f docker-compose.prod.yml logs scraper --tail=50
 ```
@@ -34,21 +54,23 @@ docker compose -f docker-compose.prod.yml logs scraper --tail=50
 
 ## Release with a DB migration
 
-Run the migration **before** restarting services. A running web container will
-continue serving the old schema while the migration applies cleanly.
+`deploy.sh` **already runs `db:migrate` before `up -d`** on every deploy — the migration
+applies while the old web container keeps serving the old schema, then services restart.
+So a migration release is the same `./scripts/deploy.sh`. The migration SQL is baked into
+the pulled scraper image, so there is no "rebuild first" caveat anymore — the pulled image
+*is* the fixed image.
 
-> **Important:** `db:migrate` uses whatever migration files are baked into the
-> running scraper image. If this release **modifies an existing migration file**
-> (not just adds a new one), rebuild the scraper image first so `db:migrate`
-> picks up the fixed files — then proceed as normal.
+For a migration you want to eyeball before restarting, run the steps by hand:
 
 ```bash
 cd /opt/mtg-au-tracker
+git pull --ff-only
+export IMAGE_TAG=latest   # or main-<sha>
 
-# 1. Pull latest
-git pull
+# 1. Pull the new images
+docker compose -f docker-compose.prod.yml pull web scraper
 
-# 2. Apply migration (safe to run against live DB)
+# 2. Apply migration (safe against live DB)
 docker compose -f docker-compose.prod.yml run --rm scraper \
   pnpm --filter @mtg-au/scraper db:migrate
 
@@ -57,13 +79,21 @@ docker compose -f docker-compose.prod.yml exec db \
   psql -U mtg -d mtg_tracker -c \
   "SELECT version, created_at FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"
 
-# 4. Rebuild and restart
+# 4. Restart
+docker compose -f docker-compose.prod.yml up -d
+docker compose -f docker-compose.prod.yml ps
+```
+
+---
+
+## Emergency: build on the server
+
+Building on the server is no longer the deploy path, but the `build:` blocks remain in
+`docker-compose.prod.yml` as a fallback (e.g. GHCR is down). To use it:
+
+```bash
 docker compose -f docker-compose.prod.yml build web scraper
 docker compose -f docker-compose.prod.yml up -d
-
-# 5. Verify services are healthy
-docker compose -f docker-compose.prod.yml ps
-docker compose -f docker-compose.prod.yml logs web --tail=50
 ```
 
 ---
@@ -95,11 +125,16 @@ Expected: ~32k cards, ~141k printings, ~700+ sets with `set_type` populated.
 
 ### Code-only rollback
 
+Re-deploy the previous image tag — no rebuild, no revert commit needed. Find the prior
+`main-<sha>` tag under the repo's GitHub Packages (or from the earlier deploy log):
+
 ```bash
-git revert HEAD   # or: git checkout <previous-commit>
-docker compose -f docker-compose.prod.yml build web scraper
-docker compose -f docker-compose.prod.yml up -d
+./scripts/deploy.sh main-abc1234
 ```
+
+`deploy.sh` still runs `db:migrate` on rollback; that's a no-op if the older image's
+migrations are already applied. Only revert the code in git if the bad change also needs
+backing out of `main`.
 
 ### Migration rollback
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Pull-based production deploy. Images are built + pushed by GitHub Actions
+# (.github/workflows/deploy-images.yml) — this script never builds them.
+#
+# Usage:
+#   ./scripts/deploy.sh                 # deploy :latest
+#   ./scripts/deploy.sh main-abc1234    # pin/rollback to a specific image tag
+#
+# Run from the repo checkout on the server (e.g. /opt/mtg-au-tracker).
+set -euo pipefail
+
+REPO_DIR="${REPO_DIR:-/opt/mtg-au-tracker}"
+COMPOSE_FILE="docker-compose.prod.yml"
+export IMAGE_TAG="${1:-latest}"
+
+cd "$REPO_DIR"
+
+# Refresh the compose file, migration SQL, and this script on disk.
+# (Not a build — the app itself ships inside the pulled images.)
+git pull --ff-only
+
+echo "==> Pulling images (tag: ${IMAGE_TAG})"
+docker compose -f "$COMPOSE_FILE" pull web scraper
+
+# Apply migrations from the freshly pulled scraper image, BEFORE restarting
+# services, so the running web keeps serving the old schema until it's ready.
+echo "==> Applying DB migrations"
+docker compose -f "$COMPOSE_FILE" run --rm scraper \
+  pnpm --filter @mtg-au/scraper db:migrate
+
+echo "==> Starting services"
+docker compose -f "$COMPOSE_FILE" up -d
+
+docker compose -f "$COMPOSE_FILE" ps
+echo "==> Deploy complete (tag: ${IMAGE_TAG})"


### PR DESCRIPTION
GitHub Actions now builds both images and pushes them to GHCR on every merge to main (.github/workflows/deploy-images.yml). The server no longer builds — it pulls via scripts/deploy.sh (git pull -> compose pull -> db:migrate -> up -d). docker-compose.prod.yml references images through ${IMAGE_REGISTRY}/scrymarket-{web,scraper}:${IMAGE_TAG} with the build: blocks kept only as an emergency fallback.

Deliberately AWS-ready: the image is the deploy artifact, migrations are a discrete command, and IMAGE_REGISTRY makes a future GHCR->ECR move a config swap. amd64-only for now (server + Fargate x86).

Docs (prod-release.md, CLAUDE.md) updated for the pull-based flow and tag-based rollback (./scripts/deploy.sh main-<sha>).