### PR TITLE
fix(web): stop search seq-scanning all printings on every query

### DIFF
--- a/apps/scraper/drizzle/0013_cards_name_trgm.sql
+++ b/apps/scraper/drizzle/0013_cards_name_trgm.sql
@@ -1,0 +1,7 @@
+-- Trigram index to support the leading-wildcard ILIKE in searchCards()/countCards().
+-- Without it, a selective query like '%bolt%' scans all of `cards` (~6.9k buffers);
+-- with it, the same search reads ~226. Broad queries ('%a%') still use cards_name_idx,
+-- which the planner picks on cost.
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "cards_name_trgm_idx" ON "cards" USING gin ("name" gin_trgm_ops);

--- a/apps/scraper/drizzle/meta/_journal.json
+++ b/apps/scraper/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1783851698295,
       "tag": "0012_pretty_butterfly",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1786000000000,
+      "tag": "0013_cards_name_trgm",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/scraper/src/lib/schema.ts
+++ b/apps/scraper/src/lib/schema.ts
@@ -28,6 +28,7 @@ import {
   date,
   numeric,
 } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
 // Note: price_history is a PARTITIONED table (RANGE by recorded_at, monthly).
 // Drizzle does not model the partition structure — it sees the parent table only.
 // The id column was dropped as part of partitioning; natural key is
@@ -72,6 +73,9 @@ export const cards = pgTable(
   (table) => [
     index("cards_name_idx").on(table.name),                // fast name lookups
     uniqueIndex("cards_slug_idx").on(table.slug),          // slug lookups for SEO routes
+    // Trigram index for the leading-wildcard ILIKE in searchCards()/countCards();
+    // a btree can't serve '%bolt%'. Requires the pg_trgm extension (migration 0013).
+    index("cards_name_trgm_idx").using("gin", sql`${table.name} gin_trgm_ops`),
   ]
 );
 

--- a/apps/web/src/lib/db/cards.ts
+++ b/apps/web/src/lib/db/cards.ts
@@ -96,31 +96,42 @@ export const PAGE_SIZE = SEARCH_PAGE_SIZE;
 
 export async function searchCards(query: string, offset = 0): Promise<CardSearchResult[]> {
   if (!query.trim()) return [];
+  // Page the `cards` table on its own first, then look up printing count/art for
+  // just those rows. Joining `printings` before the LIMIT made every search seq-scan
+  // all ~148k printings, aggregate a ~113k-row join, and spill ~20MB to a disk sort
+  // before discarding all but 20 rows.
   return sql<CardSearchResult[]>`
+    WITH matched AS (
+      SELECT c.id, c.slug, c.name, c.type_line, c.colors, c.scrymarket_price, c.price_trend
+      FROM cards c
+      WHERE c.name ILIKE ${"%" + query + "%"}
+      ORDER BY c.name, c.id
+      LIMIT ${PAGE_SIZE} OFFSET ${offset}
+    )
     SELECT
-      c.id,
-      c.slug,
-      c.name,
-      c.type_line,
-      c.colors,
-      COUNT(DISTINCT p.id)::int AS printing_count,
+      m.id,
+      m.slug,
+      m.name,
+      m.type_line,
+      m.colors,
+      (
+        SELECT COUNT(*)::int
+        FROM printings p
+        WHERE p.card_id = m.id
+      ) AS printing_count,
       (
         SELECT p2.image_uri
         FROM printings p2
-        WHERE p2.card_id = c.id
+        WHERE p2.card_id = m.id
           AND p2.image_uri IS NOT NULL
           AND p2.is_foil = false
         ORDER BY p2.released_at DESC
         LIMIT 1
       ) AS image_uri,
-      c.scrymarket_price::text AS scrymarket_price,
-      c.price_trend AS trend
-    FROM cards c
-    LEFT JOIN printings p ON p.card_id = c.id
-    WHERE c.name ILIKE ${"%" + query + "%"}
-    GROUP BY c.id, c.name, c.type_line, c.colors, c.scrymarket_price, c.price_trend
-    ORDER BY c.name
-    LIMIT ${PAGE_SIZE} OFFSET ${offset}
+      m.scrymarket_price::text AS scrymarket_price,
+      m.price_trend AS trend
+    FROM matched m
+    ORDER BY m.name, m.id
   `;
 }
 


### PR DESCRIPTION
searchCards() joined `printings` before the LIMIT purely to compute a printing count. Every search therefore seq-scanned all ~148k printings, aggregated a ~113k-row join, spilled ~20MB to an external merge sort, and then discarded all but 20 rows: ~19k block reads plus ~2.5k temp blocks per call, 295ms. Infinite scroll re-runs it per page of 20, so a single broad query multiplies that — enough disk traffic to drive the host into IO delay.

Page `cards` on its own first, then resolve printing count and art via scalar subqueries for only the 20 surviving rows. Add a pg_trgm GIN index since the leading-wildcard ILIKE can't use a btree; the planner still picks cards_name_idx for broad terms on cost.

  %a%     19,094 buf + 20MB disk sort, 295ms -> 191 buf, 0.9ms
  %bolt%  19,094 buf + disk sort            -> 226 buf
  no match 19,094 buf + disk sort           -> 20 buf

Also order by (name, id) rather than name alone — name isn't unique, so an unstable tiebreak could duplicate or skip rows across scroll pages.

Verified old and new queries return identical rows across five search terms; both packages typecheck and all 402 tests pass.